### PR TITLE
Implement adding/removing components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,6 @@
             <version>${flow.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>flow-html-components</artifactId>
-            <version>${flow.version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>flow-html-components</artifactId>
             <version>${flow.version}</version>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Dependencies for the demo -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,5 @@
             <version>${flow.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-ordered-layout-flow</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -15,47 +15,84 @@
  */
 package com.vaadin.flow.component.dialog;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.server.VaadinRequest;
 
 /**
  * Server-side component for the {@code <vaadin-dialog>} element.
  * 
  * @author Vaadin Ltd
  */
-public class Dialog extends GeneratedVaadinDialog<Dialog> {
+@HtmlImport("bower_components/polymer/polymer.html")
+@HtmlImport("frontend://flow-component-renderer.html")
+public class Dialog extends GeneratedVaadinDialog<Dialog>
+        implements HasComponents {
+
+    private Element container;
 
     /**
      * Creates an empty dialog.
      */
     public Dialog() {
-        this("");
+        container = new Element("div", false);
+        getElement().appendVirtualChild(container);
+
+        getElement().getNode().runWhenAttached(ui -> {
+            String appId = UI.getCurrent().getSession().getService()
+                    .getMainDivId(UI.getCurrent().getSession(),
+                            VaadinRequest.getCurrent());
+            appId = appId.substring(0, appId.indexOf("-"));
+
+            int nodeId = container.getNode().getId();
+
+            String template = "<template><flow-component-renderer appid="
+                    + appId + " nodeid=" + nodeId
+                    + "></flow-component-renderer></template>";
+            getElement().setProperty("innerHTML", template);
+        });
     }
 
     /**
-     * Creates a dialog with the given String rendered as it's HTML content.
+     * Creates a dialog with given components inside.
      * 
-     * @param content
-     *            the content of the Dialog as HTML markup
+     * @param components
+     *            the components inside the dialog
+     * @see #add(Component...)
      */
-    public Dialog(String content) {
-        Element templateElement = new Element("template");
-        getElement().appendChild(templateElement);
-
-        templateElement.setProperty("innerHTML", content);
+    public Dialog(Component... components) {
+        this();
+        add(components);
     }
 
-    /**
-     * Opens the dialog.
-     */
-    public void open() {
-        setOpened(true);
+    @Override
+    public void add(Component... components) {
+        assert components != null;
+        for (Component component : components) {
+            assert component != null;
+            container.appendChild(component.getElement());
+        }
     }
 
-    /**
-     * Closes the dialog.
-     */
-    public void close() {
-        setOpened(false);
+    @Override
+    public void remove(Component... components) {
+        for (Component component : components) {
+            assert component != null;
+            if (container.equals(component.getElement().getParent())) {
+                container.removeChild(component.getElement());
+            } else {
+                throw new IllegalArgumentException("The given component ("
+                        + component + ") is not a child of this component");
+            }
+        }
+    }
+
+    @Override
+    public void removeAll() {
+        container.removeAllChildren();
     }
 
     /**
@@ -106,6 +143,31 @@ public class Dialog extends GeneratedVaadinDialog<Dialog> {
      */
     public void setCloseOnOutsideClick(boolean closeOnOutsideClick) {
         getElement().setProperty("noCloseOnOutsideClick", !closeOnOutsideClick);
+    }
+
+    /**
+     * Opens the dialog.
+     */
+    public void open() {
+        setOpened(true);
+    }
+
+    /**
+     * Closes the dialog.
+     */
+    public void close() {
+        setOpened(false);
+    }
+
+    @Override
+    public void setOpened(boolean opened) {
+        if (opened && !getElement().getNode().isAttached()
+                && UI.getCurrent() != null) {
+            // Add the element to body when it's opened,
+            // if it hasn't been attached already somewhere.
+            UI.getCurrent().add(this);
+        }
+        super.setOpened(opened);
     }
 
 }

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -41,18 +41,20 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         container = new Element("div", false);
         getElement().appendVirtualChild(container);
 
-        getElement().getNode().runWhenAttached(ui -> {
-            String appId = ui.getSession().getService()
-                    .getMainDivId(ui.getSession(), VaadinRequest.getCurrent());
-            appId = appId.substring(0, appId.indexOf("-"));
+        // Attach <flow-component-renderer>
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this, () -> {
+                    String appId = ui.getSession().getService().getMainDivId(
+                            ui.getSession(), VaadinRequest.getCurrent());
+                    appId = appId.substring(0, appId.indexOf("-"));
 
-            int nodeId = container.getNode().getId();
+                    int nodeId = container.getNode().getId();
 
-            String template = "<template><flow-component-renderer appid="
-                    + appId + " nodeid=" + nodeId
-                    + "></flow-component-renderer></template>";
-            getElement().setProperty("innerHTML", template);
-        });
+                    String template = "<template><flow-component-renderer appid="
+                            + appId + " nodeid=" + nodeId
+                            + "></flow-component-renderer></template>";
+                    getElement().setProperty("innerHTML", template);
+                }));
     }
 
     /**

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -20,14 +20,12 @@ import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.server.VaadinRequest;
 
 /**
  * Server-side component for the {@code <vaadin-dialog>} element.
  * 
  * @author Vaadin Ltd
  */
-@HtmlImport("bower_components/polymer/polymer.html")
 @HtmlImport("frontend://flow-component-renderer.html")
 public class Dialog extends GeneratedVaadinDialog<Dialog>
         implements HasComponents {
@@ -42,19 +40,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendVirtualChild(container);
 
         // Attach <flow-component-renderer>
-        getElement().getNode()
-                .runWhenAttached(ui -> ui.beforeClientResponse(this, () -> {
-                    String appId = ui.getSession().getService().getMainDivId(
-                            ui.getSession(), VaadinRequest.getCurrent());
-                    appId = appId.substring(0, appId.indexOf("-"));
-
-                    int nodeId = container.getNode().getId();
-
-                    String template = "<template><flow-component-renderer appid="
-                            + appId + " nodeid=" + nodeId
-                            + "></flow-component-renderer></template>";
-                    getElement().setProperty("innerHTML", template);
-                }));
+        getElement().getNode().runWhenAttached(ui -> ui
+                .beforeClientResponse(this, () -> attachComponentRenderer()));
     }
 
     /**
@@ -193,6 +180,15 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
             UI.getCurrent().add(this);
         }
         super.setOpened(opened);
+    }
+
+    private void attachComponentRenderer() {
+        String appId = UI.getCurrent().getInternals().getAppId();
+        int nodeId = container.getNode().getId();
+        String template = "<template><flow-component-renderer appid=" + appId
+                + " nodeid=" + nodeId
+                + "></flow-component-renderer></template>";
+        getElement().setProperty("innerHTML", template);
     }
 
 }

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -42,9 +42,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendVirtualChild(container);
 
         getElement().getNode().runWhenAttached(ui -> {
-            String appId = UI.getCurrent().getSession().getService()
-                    .getMainDivId(UI.getCurrent().getSession(),
-                            VaadinRequest.getCurrent());
+            String appId = ui.getSession().getService()
+                    .getMainDivId(ui.getSession(), VaadinRequest.getCurrent());
             appId = appId.substring(0, appId.indexOf("-"));
 
             int nodeId = container.getNode().getId();

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -68,6 +68,16 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         add(components);
     }
 
+    /**
+     * Adds the given components into this dialog.
+     * <p>
+     * The elements in the DOM will not be children of the
+     * {@code <vaadin-dialog>} element, but will be inserted into an overlay
+     * that is attached into the {@code <body>}.
+     *
+     * @param components
+     *            the components to add
+     */
     @Override
     public void add(Component... components) {
         assert components != null;
@@ -147,6 +157,11 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     /**
      * Opens the dialog.
+     * <p>
+     * Note: You don't need to add the dialog component anywhere before opening
+     * it. Since {@code <vaadin-dialog>}'s location in the DOM doesn't really
+     * matter, opening a dialog will automatically add it to the {@code <body>}
+     * if it's not yet attached anywhere.
      */
     public void open() {
         setOpened(true);
@@ -159,12 +174,21 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         setOpened(false);
     }
 
+    /**
+     * Opens or closes the dialog.
+     * <p>
+     * Note: You don't need to add the dialog component anywhere before opening
+     * it. Since {@code <vaadin-dialog>}'s location in the DOM doesn't really
+     * matter, opening a dialog will automatically add it to the {@code <body>}
+     * if it's not yet attached anywhere.
+     * 
+     * @param opened
+     *            {@code true} to open the dialog, {@code false} to close it
+     */
     @Override
     public void setOpened(boolean opened) {
         if (opened && !getElement().getNode().isAttached()
                 && UI.getCurrent() != null) {
-            // Add the element to body when it's opened,
-            // if it hasn't been attached already somewhere.
             UI.getCurrent().add(this);
         }
         super.setOpened(opened);

--- a/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.component.dialog.demo;
 
-import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
@@ -28,7 +27,6 @@ import com.vaadin.flow.router.Route;
  * @author Vaadin Ltd
  */
 @Route("vaadin-dialog")
-@HtmlImport("bower_components/vaadin-valo-theme/vaadin-dialog.html")
 public class DialogView extends DemoView {
 
     private static final String BUTTON_CAPTION = "Open dialog";

--- a/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -19,7 +19,6 @@ import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
 
@@ -29,7 +28,7 @@ import com.vaadin.flow.router.Route;
  * @author Vaadin Ltd
  */
 @Route("vaadin-dialog")
-@HtmlImport("bower_components/vaadin-valo-theme/vaadin-button.html")
+@HtmlImport("bower_components/vaadin-valo-theme/vaadin-dialog.html")
 public class DialogView extends DemoView {
 
     private static final String BUTTON_CAPTION = "Open dialog";
@@ -37,8 +36,7 @@ public class DialogView extends DemoView {
     @Override
     public void initView() {
         addBasicDialog();
-        addDialogWithOpenedChangedListener();
-        addDialogWithHTML();
+        addConfirmationDialog();
     }
 
     private void addBasicDialog() {
@@ -46,7 +44,9 @@ public class DialogView extends DemoView {
 
         // begin-source-example
         // source-example-heading: Basic dialog
-        Dialog dialog = new Dialog("Hello World!");
+        Dialog dialog = new Dialog();
+        dialog.add(new Label("Close me with the esc-key or an outside click"));
+
         button.addClickListener(event -> dialog.open());
         // end-source-example
 
@@ -54,41 +54,31 @@ public class DialogView extends DemoView {
         addCard("Basic dialog", button, dialog);
     }
 
-    private void addDialogWithOpenedChangedListener() {
+    private void addConfirmationDialog() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
-        Label message = new Label();
-        Dialog dialog = new Dialog("Hello World!");
 
         // begin-source-example
-        // source-example-heading: Dialog with an OpenedChangedListener
-        dialog.addOpenedChangeListener(event -> {
-            if (dialog.isOpened()) {
-                message.setText("Dialog opened!");
-            } else {
-                message.setText("Dialog closed!");
-            }
+        // source-example-heading: Confirmation dialog
+        Dialog dialog = new Dialog();
+
+        dialog.setCloseOnEsc(false);
+        dialog.setCloseOnOutsideClick(false);
+
+        Label messageLabel = new Label();
+
+        NativeButton confirmButton = new NativeButton("Confirm", event -> {
+            messageLabel.setText("Confirmed!");
+            dialog.close();
         });
+        NativeButton cancelButton = new NativeButton("Cancel", event -> {
+            messageLabel.setText("Cancelled...");
+            dialog.close();
+        });
+        dialog.add(confirmButton, cancelButton);
         // end-source-example
-
         button.addClickListener(event -> dialog.open());
-        button.setId("dialog-with-listener-button");
-        message.setId("dialog-message-label");
-        addCard("Dialog with an OpenedChangedListener",
-                new HorizontalLayout(button, message), dialog);
-    }
 
-    private void addDialogWithHTML() {
-        NativeButton button = new NativeButton(BUTTON_CAPTION);
-
-        // begin-source-example
-        // source-example-heading: Dialog with HTML content
-        Dialog dialog = new Dialog("<b>Dialog can be closed by:</b><ul>"
-                + "<li>Hitting the esc key</li>"
-                + "<li>Clicking outside of it</li></ul>");
-        // end-source-example
-
-        button.addClickListener(event -> dialog.open());
-        button.setId("dialog-with-html-button");
-        addCard("Dialog with HTML content", button, dialog);
+        button.setId("confirmation-dialog-button");
+        addCard("Confirmation dialog", button, dialog, messageLabel);
     }
 }

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -33,39 +33,27 @@ public class DialogIT extends ComponentDemoTest {
     private static final String DIALOG_OVERLAY_TAG = "vaadin-dialog-overlay";
 
     @Test
-    public void openAndCloseBasicDialog() {
+    public void openAndCloseBasicDialog_labelRendered() {
         findElement(By.id("basic-dialog-button")).click();
-        assertDialogOverlayContent("Hello World!");
+        getOverlayContent().findElement(By.tagName("label"));
 
-        closeAndVerify();
+        new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
+        verifyDialogClosed();
     }
 
     @Test
-    public void openAndCloseDialogWithListener() {
-        WebElement label = findElement(By.id("dialog-message-label"));
-        Assert.assertTrue(label.getText().isEmpty());
+    public void openAndCloseConfirmationDialog_buttonsRenderedWithClickListeners() {
+        WebElement messageLabel = findElement(By.tagName("label"));
 
-        findElement(By.id("dialog-with-listener-button")).click();
-        assertDialogOverlayContent("Hello World!");
-        Assert.assertTrue(label.getText().contains("opened"));
+        findElement(By.id("confirmation-dialog-button")).click();
+        getOverlayContent().findElements(By.tagName("button")).get(0).click();
+        verifyDialogClosed();
+        Assert.assertEquals("Confirmed!", messageLabel.getText());
 
-        closeAndVerify();
-        Assert.assertTrue(label.getText().contains("closed"));
-    }
-
-    @Test
-    public void openAndCloseDialogWithHtml() {
-        scrollIntoViewAndClick(findElement(By.id("dialog-with-html-button")));
-
-        getOverlayContent().findElement(By.tagName("b"));
-        getOverlayContent().findElement(By.tagName("ul"));
-
-        closeAndVerify();
-    }
-
-    private void assertDialogOverlayContent(String expected) {
-        String content = getOverlayContent().getText();
-        Assert.assertTrue(content.contains(expected));
+        findElement(By.id("confirmation-dialog-button")).click();
+        getOverlayContent().findElements(By.tagName("button")).get(1).click();
+        verifyDialogClosed();
+        Assert.assertEquals("Cancelled...", messageLabel.getText());
     }
 
     private WebElement getOverlayContent() {
@@ -73,8 +61,7 @@ public class DialogIT extends ComponentDemoTest {
         return getInShadowRoot(overlay, By.id("content"));
     }
 
-    private void closeAndVerify() {
-        new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
+    private void verifyDialogClosed() {
         waitForElementNotPresent(By.tagName(DIALOG_OVERLAY_TAG));
     }
 


### PR DESCRIPTION
Used `<flow-component-renderer>` to be able to add and remove components in a dialog. Removed most of the boring old demos and added a demo about a confirmation-dialog.

Also, now dialog adds itself to the `<body>` when opened, if it's not yet attached. So users can just call dialog.open() without adding the component anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/19)
<!-- Reviewable:end -->
