### PR TITLE
Properly construct the template-element instead of setting as innerHTML

### DIFF
--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -30,12 +30,16 @@ import com.vaadin.flow.dom.Element;
 public class Dialog extends GeneratedVaadinDialog<Dialog>
         implements HasComponents {
 
+    private Element template;
     private Element container;
 
     /**
      * Creates an empty dialog.
      */
     public Dialog() {
+        template = new Element("template");
+        getElement().appendChild(template);
+
         container = new Element("div", false);
         getElement().appendVirtualChild(container);
 
@@ -194,11 +198,9 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     private void attachComponentRenderer() {
         String appId = UI.getCurrent().getInternals().getAppId();
         int nodeId = container.getNode().getId();
-        String template = "<template><flow-component-renderer appid=" + appId
-                + " nodeid=" + nodeId
-                + "></flow-component-renderer></template>";
-        getElement().setProperty("innerHTML", template);
+        String renderer = "<flow-component-renderer appid=" + appId + " nodeid="
+                + nodeId + "></flow-component-renderer>";
+        template.setProperty("innerHTML", renderer);
     }
 
 }
-

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -37,7 +37,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      * Creates an empty dialog.
      */
     public Dialog() {
-        template = new Element("template");
+        template = new Element("template", false);
         getElement().appendChild(template);
 
         container = new Element("div", false);
@@ -198,8 +198,9 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     private void attachComponentRenderer() {
         String appId = UI.getCurrent().getInternals().getAppId();
         int nodeId = container.getNode().getId();
-        String renderer = "<flow-component-renderer appid=" + appId + " nodeid="
-                + nodeId + "></flow-component-renderer>";
+        String renderer = String.format(
+                "<flow-component-renderer appid=\"%s\" nodeid=\"%s\"></flow-component-renderer>",
+                appId, nodeId);
         template.setProperty("innerHTML", renderer);
     }
 


### PR DESCRIPTION
The component didn't work on IE11 because the <template> was set as innerHTML, and the <template>-polyfill couldn't handle that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/29)
<!-- Reviewable:end -->
