### PR TITLE
Dialog is now removed from the DOM when closed

### DIFF
--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -34,6 +34,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     private Element template;
     private Element container;
+    private boolean autoAddedToTheUi = false;
 
     /**
      * Creates an empty dialog.
@@ -48,6 +49,13 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         // Attach <flow-component-renderer>
         getElement().getNode().runWhenAttached(ui -> ui
                 .beforeClientResponse(this, () -> attachComponentRenderer()));
+
+        addOpenedChangeListener(event -> {
+            if (autoAddedToTheUi && !isOpened()) {
+                getElement().removeFromParent();
+                autoAddedToTheUi = false;
+            }
+        });
     }
 
     /**
@@ -184,7 +192,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         UI ui = UI.getCurrent();
         if (opened && getElement().getNode().getParent() == null
                 && ui != null) {
-            ui.beforeClientResponse(ui, () -> ui.add(this));
+            ui.beforeClientResponse(ui, () -> {
+                ui.add(this);
+                autoAddedToTheUi = true;
+            });
         }
         super.setOpened(opened);
     }

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -34,6 +34,7 @@ public class DialogTestPage extends Div {
 
     public DialogTestPage() {
         createDialogWithAddOpenedChangeListener();
+        createDialogWithoutAddingToTheUi();
     }
 
     private void createDialogWithAddOpenedChangeListener() {
@@ -51,6 +52,21 @@ public class DialogTestPage extends Div {
         dialog.addOpenedChangeListener(event -> message.setText(
                 "The open state of the dialog is " + dialog.isOpened()));
         add(button, message, dialog);
+    }
+
+    private void createDialogWithoutAddingToTheUi() {
+        NativeButton open = new NativeButton("Open dialog not attached");
+        open.setId("dialog-outside-ui-open");
+        NativeButton close = new NativeButton("Close dialog");
+        close.setId("dialog-outside-ui-close");
+
+        Dialog dialog = new Dialog();
+        dialog.setId("dialog-outside-ui");
+        dialog.add(new Label("Hei! Moika! Moi!"), close);
+
+        open.addClickListener(event -> dialog.open());
+        close.addClickListener(event -> dialog.close());
+        add(open);
     }
 
 }

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -29,10 +27,12 @@ import org.openqa.selenium.WebElement;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
 
+import static org.junit.Assert.assertTrue;
+
 @TestPath("dialog-test")
 public class DialogTestPageIT extends AbstractComponentIT {
 
-    static final String DIALOG_TAG = "vaadin-dialog-overlay";
+    static final String DIALOG_OVERLAY_TAG = "vaadin-dialog-overlay";
 
     @Before
     public void init() {
@@ -47,23 +47,46 @@ public class DialogTestPageIT extends AbstractComponentIT {
                 .equals(findElement(By.id("message")).getText()));
 
         findElement(By.id("dialog-open")).click();
-        checkDialogIsOpen();
+        checkDialogIsOpened();
         assertTrue("The open state of the dialog is true"
                 .equals(findElement(By.id("message")).getText()));
         assertDialogContent(
                 "There is a opened change listener for this dialog");
         executeScript("document.body.click()");
-        checkDialogIsClose();
+        checkDialogIsClosed();
         assertTrue("The open state of the dialog is false"
                 .equals(findElement(By.id("message")).getText()));
     }
 
-    private void checkDialogIsClose() {
-        waitForElementNotPresent(By.tagName(DIALOG_TAG));
+    @Test
+    public void dialogNotAttachedToThePage_openAndClose_dialogIsAttachedAndRemoved() {
+        WebElement open = findElement(By.id("dialog-outside-ui-open"));
+
+        waitForElementNotPresent(By.id("dialog-outside-ui"));
+        open.click();
+        waitForElementPresent(By.id("dialog-outside-ui"));
+        checkDialogIsOpened();
+        executeScript("document.body.click()");
+        checkDialogIsClosed();
+        waitForElementNotPresent(By.id("dialog-outside-ui"));
+
+        open.click();
+        waitForElementPresent(By.id("dialog-outside-ui"));
+        checkDialogIsOpened();
+        WebElement overlay = findElement(By.tagName(DIALOG_OVERLAY_TAG));
+        WebElement close = findInShadowRoot(overlay,
+                By.id("dialog-outside-ui-close")).get(0);
+        close.click();
+        checkDialogIsClosed();
+        waitForElementNotPresent(By.id("dialog-outside-ui"));
     }
 
-    private void checkDialogIsOpen() {
-        waitForElementPresent(By.tagName(DIALOG_TAG));
+    private void checkDialogIsClosed() {
+        waitForElementNotPresent(By.tagName(DIALOG_OVERLAY_TAG));
+    }
+
+    private void checkDialogIsOpened() {
+        waitForElementPresent(By.tagName(DIALOG_OVERLAY_TAG));
     }
 
     private void assertDialogContent(String expected) {
@@ -73,6 +96,6 @@ public class DialogTestPageIT extends AbstractComponentIT {
     }
 
     private List<WebElement> getDialogs() {
-        return findElements(By.tagName(DIALOG_TAG));
+        return findElements(By.tagName(DIALOG_OVERLAY_TAG));
     }
 }

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithTemplateIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithTemplateIT.java
@@ -40,9 +40,9 @@ public class DialogWithTemplateIT extends AbstractComponentIT {
         WebElement open = findElement(By.id("open"));
         open.click();
 
-        waitForElementPresent(By.tagName(DialogTestPageIT.DIALOG_TAG));
+        waitForElementPresent(By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
         WebElement overlay = findElement(
-                By.tagName(DialogTestPageIT.DIALOG_TAG));
+                By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
         WebElement template = findInShadowRoot(overlay, By.id("template"))
                 .get(0);
 

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/InitiallyOpenedDialogPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/InitiallyOpenedDialogPageIT.java
@@ -34,9 +34,9 @@ public class InitiallyOpenedDialogPageIT extends AbstractComponentIT {
 
     @Test
     public void openDialogDuringPageLoad() {
-        waitForElementPresent(By.tagName(DialogTestPageIT.DIALOG_TAG));
+        waitForElementPresent(By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
         WebElement overlay = findElement(
-                By.tagName(DialogTestPageIT.DIALOG_TAG));
+                By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
         Assert.assertTrue(
                 isPresentInShadowRoot(overlay, By.id("nested-component")));
     }


### PR DESCRIPTION
The Dialog is removed when it is automatically added to the DOM during the `open()` call. If the user decides to add it to the DOM by himself, then the Dialog is not removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/44)
<!-- Reviewable:end -->
