### PR TITLE
Improve javadocs of attach and detach listeners

### DIFF
--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -18,9 +18,11 @@ package com.vaadin.flow.component.dialog;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
@@ -175,6 +177,9 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     /**
      * Closes the dialog.
+     * <p>
+     * Note: This method also removes the dialog component from the DOM after
+     * closing it, unless you have added the component manually.
      */
     public void close() {
         setOpened(false);
@@ -232,6 +237,31 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     public Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<Dialog>> listener) {
         return super.addOpenedChangeListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note: To listen for opening the dialog, you should use
+     * {@link #addOpenedChangeListener(ComponentEventListener)}.
+     */
+    @Override
+    public Registration addAttachListener(
+            ComponentEventListener<AttachEvent> listener) {
+        return super.addAttachListener(listener);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note: To listen for closing the dialog, you should use
+     * {@link #addOpenedChangeListener(ComponentEventListener)}, as the
+     * component is not necessarily removed from the DOM when closing.
+     */
+    @Override
+    public Registration addDetachListener(
+            ComponentEventListener<DetachEvent> listener) {
+        return super.addDetachListener(listener);
     }
 
     private void attachComponentRenderer() {


### PR DESCRIPTION
to emphasize that they don't necessarily listen to opening and closing the dialog

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/45)
<!-- Reviewable:end -->
