### PR TITLE
Update generated component and fix API change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-dialog</artifactId>
-            <version>2.0.0-beta1</version>
+            <version>2.0.0-beta2</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -53,10 +53,14 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendChild(container);
 
         // Attach <flow-component-renderer>
-        getElement().getNode().runWhenAttached(ui -> ui
-                .beforeClientResponse(this, () -> attachComponentRenderer()));
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.beforeClientResponse(this,
+                        context -> attachComponentRenderer()));
 
-        addOpenedChangeListener(event -> {
+        // Workaround for: https://github.com/vaadin/flow/issues/3496
+        setOpened(false);
+
+        getElement().addEventListener("opened-changed", event -> {
             if (autoAddedToTheUi && !isOpened()) {
                 getElement().removeFromParent();
                 autoAddedToTheUi = false;
@@ -201,7 +205,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         UI ui = UI.getCurrent();
         if (opened && getElement().getNode().getParent() == null
                 && ui != null) {
-            ui.beforeClientResponse(ui, () -> {
+            ui.beforeClientResponse(ui, context -> {
                 ui.add(this);
                 autoAddedToTheUi = true;
             });

--- a/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -22,7 +22,6 @@ import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -32,7 +31,7 @@ import com.vaadin.flow.shared.Registration;
  * Description copied from corresponding location in WebComponent:
  * </p>
  * <p>
- * {@code <vaadin-dialog>} is a Polymer 2 element for customised modal dialogs.
+ * {@code <vaadin-dialog>} is a Polymer 2 element for customized modal dialogs.
  * </p>
  * <p>
  * &lt;vaadin-dialog opened&gt; &lt;template&gt; Sample dialog &lt;/template&gt;
@@ -52,7 +51,7 @@ import com.vaadin.flow.shared.Registration;
  * </p>
  */
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
-        "WebComponent: Vaadin.VaadinDialog#null", "Flow#1.0-SNAPSHOT" })
+        "WebComponent: Vaadin.DialogElement#null", "Flow#1.0-SNAPSHOT" })
 @Tag("vaadin-dialog")
 @HtmlImport("frontend://bower_components/vaadin-dialog/src/vaadin-dialog.html")
 public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
@@ -91,11 +90,17 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
         getElement().setProperty("opened", opened);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinDialog<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -107,10 +112,12 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialogOverlay.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialogOverlay.java
@@ -44,7 +44,7 @@ import com.vaadin.flow.shared.Registration;
  * </p>
  */
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
-        "WebComponent: Vaadin.VaadinDialogOverlay#UNKNOWN",
+        "WebComponent: Vaadin.DialogOverlayElement#UNKNOWN",
         "Flow#1.0-SNAPSHOT" })
 @Tag("vaadin-dialog-overlay")
 @HtmlImport("frontend://bower_components/vaadin-dialog/src/vaadin-dialog.html")
@@ -294,11 +294,17 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinDialogOverlay<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -310,18 +316,26 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("template-changed")
     public static class TemplateChangeEvent<R extends GeneratedVaadinDialogOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject template;
+
         public TemplateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.template = source.getTemplateJsonObject();
+        }
+
+        public JsonObject getTemplate() {
+            return template;
         }
     }
 
@@ -333,18 +347,26 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addTemplateChangeListener(
             ComponentEventListener<TemplateChangeEvent<R>> listener) {
-        return addListener(TemplateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("template",
+                        event -> listener.onComponentEvent(
+                                new TemplateChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("content-changed")
     public static class ContentChangeEvent<R extends GeneratedVaadinDialogOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject content;
+
         public ContentChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.content = source.getContentJsonObject();
+        }
+
+        public JsonObject getContent() {
+            return content;
         }
     }
 
@@ -356,10 +378,12 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addContentChangeListener(
             ComponentEventListener<ContentChangeEvent<R>> listener) {
-        return addListener(ContentChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("content",
+                        event -> listener.onComponentEvent(
+                                new ContentChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -49,7 +49,7 @@ public class DialogView extends DemoView {
         // end-source-example
 
         button.setId("basic-dialog-button");
-        addCard("Basic dialog", button, dialog);
+        addCard("Basic dialog", button);
     }
 
     private void addConfirmationDialog() {
@@ -78,6 +78,6 @@ public class DialogView extends DemoView {
 
         messageLabel.setId("confirmation-dialog-label");
         button.setId("confirmation-dialog-button");
-        addCard("Confirmation dialog", button, dialog, messageLabel);
+        addCard("Confirmation dialog", button, messageLabel);
     }
 }

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -32,6 +32,8 @@ public class DialogTestPage extends Div {
 
     private static final String BUTTON_CAPTION = "Open dialog";
 
+    private int eventCounter;
+
     public DialogTestPage() {
         createDialogWithAddOpenedChangeListener();
         createDialogWithoutAddingToTheUi();
@@ -40,8 +42,15 @@ public class DialogTestPage extends Div {
     private void createDialogWithAddOpenedChangeListener() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
         button.setId("dialog-open");
+
         Div message = new Div();
         message.setId("message");
+
+        Div eventCounterMessage = new Div();
+        eventCounterMessage.setId("event-counter-message");
+
+        Div eventSourceMessage = new Div();
+        eventSourceMessage.setId("event-source-message");
 
         Dialog dialog = new Dialog();
         message.setText("The open state of the dialog is " + dialog.isOpened());
@@ -49,9 +58,15 @@ public class DialogTestPage extends Div {
                 new Label("There is a opened change listener for this dialog"));
         button.addClickListener(event -> dialog.open());
 
-        dialog.addOpenedChangeListener(event -> message.setText(
-                "The open state of the dialog is " + dialog.isOpened()));
-        add(button, message, dialog);
+        eventCounter = 0;
+        dialog.addOpenedChangeListener(event -> {
+            message.setText(
+                    "The open state of the dialog is " + dialog.isOpened());
+            eventCounterMessage.setText("Number of event is " + eventCounter++);
+            eventSourceMessage.setText("The event came from "
+                    + (event.isFromClient() ? "client" : "server"));
+        });
+        add(button, message, eventCounterMessage, eventSourceMessage, dialog);
     }
 
     private void createDialogWithoutAddingToTheUi() {

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -26,8 +28,6 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
-
-import static org.junit.Assert.assertTrue;
 
 @TestPath("dialog-test")
 public class DialogTestPageIT extends AbstractComponentIT {
@@ -43,19 +43,36 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
     @Test
     public void dialogWithOpenedChangeListener() {
+        WebElement message = findElement(By.id("message"));
+        WebElement eventCounterMessage = findElement(
+                By.id("event-counter-message"));
+        WebElement eventSourceMessage = findElement(
+                By.id("event-source-message"));
+
         assertTrue("The open state of the dialog is false"
-                .equals(findElement(By.id("message")).getText()));
+                .equals(message.getText()));
 
         findElement(By.id("dialog-open")).click();
         checkDialogIsOpened();
         assertTrue("The open state of the dialog is true"
-                .equals(findElement(By.id("message")).getText()));
+                .equals(message.getText()));
+        assertTrue(
+                "There should not be initial events before opening the dialog",
+                "Number of event is 0".equals(eventCounterMessage.getText()));
+        assertTrue("The event came from server"
+                .equals(eventSourceMessage.getText()));
+
         assertDialogContent(
                 "There is a opened change listener for this dialog");
+
         executeScript("document.body.click()");
         checkDialogIsClosed();
         assertTrue("The open state of the dialog is false"
-                .equals(findElement(By.id("message")).getText()));
+                .equals(message.getText()));
+        assertTrue(
+                "Number of event is 1".equals(eventCounterMessage.getText()));
+        assertTrue("The event came from client"
+                .equals(eventSourceMessage.getText()));
     }
 
     @Test

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
-import static org.junit.Assert.assertTrue;
-
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -49,30 +47,31 @@ public class DialogTestPageIT extends AbstractComponentIT {
         WebElement eventSourceMessage = findElement(
                 By.id("event-source-message"));
 
-        assertTrue("The open state of the dialog is false"
-                .equals(message.getText()));
+        Assert.assertEquals("The open state of the dialog is false",
+                message.getText());
 
         findElement(By.id("dialog-open")).click();
         checkDialogIsOpened();
-        assertTrue("The open state of the dialog is true"
-                .equals(message.getText()));
-        assertTrue(
+
+        Assert.assertEquals("The open state of the dialog is true",
+                message.getText());
+        Assert.assertEquals(
                 "There should not be initial events before opening the dialog",
-                "Number of event is 0".equals(eventCounterMessage.getText()));
-        assertTrue("The event came from server"
-                .equals(eventSourceMessage.getText()));
+                "Number of event is 0", eventCounterMessage.getText());
+        Assert.assertEquals("The event came from server",
+                eventSourceMessage.getText());
 
         assertDialogContent(
                 "There is a opened change listener for this dialog");
 
         executeScript("document.body.click()");
         checkDialogIsClosed();
-        assertTrue("The open state of the dialog is false"
-                .equals(message.getText()));
-        assertTrue(
-                "Number of event is 1".equals(eventCounterMessage.getText()));
-        assertTrue("The event came from client"
-                .equals(eventSourceMessage.getText()));
+        Assert.assertEquals("The open state of the dialog is false",
+                message.getText());
+        Assert.assertEquals("Number of event is 1",
+                eventCounterMessage.getText());
+        Assert.assertEquals("The event came from client",
+                eventSourceMessage.getText());
     }
 
     @Test


### PR DESCRIPTION
The new generated component uses `PropertyChangeListener` for `OpenedChangeEvents`, which means that server-side property-changes fire events immediately instead of waiting for client-side dom-event.
For removing the component when closing I had to revert to using the dom-event, because the value-change doesn't work after the component is removed.

The API change was that there's now a parameter for the lambda in `beforeClientResponse`.

I also added tests to verify that `OpenedChangedEvents` work properly: no extra initial event fired (currently fixed with the workaround) and correct value for `isFromClient`

Also, updated webjar to `2.0.0-beta2`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/47)
<!-- Reviewable:end -->
