### PR TITLE
Inform server that user wants to close the dialog.

### DIFF
--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -20,9 +20,11 @@ import java.util.stream.Stream.Builder;
 
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
@@ -66,6 +68,39 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                 autoAddedToTheUi = false;
             }
         });
+
+        UI.getCurrent().getPage().executeJavaScript(
+                "var f = function(e) {"
+              + "  e.preventDefault();"
+              + "  $0.dispatchEvent(new CustomEvent('vaadin-dialog-close-action'));"
+              + "};"
+              + "$0.$.overlay.addEventListener('vaadin-overlay-outside-click', f);"
+              + "$0.$.overlay.addEventListener('vaadin-overlay-escape-press', f);", getElement());
+    }
+
+    /**
+     * `vaadin-dialog-close-action` is sent when the user clicks outside the
+     * overlay or presses the escape key.
+     */
+    @DomEvent("vaadin-dialog-close-action")
+    public static class DialogCloseActionEvent extends ComponentEvent<Dialog> {
+        public DialogCloseActionEvent(Dialog source, boolean fromClient) {
+            super(source, fromClient);
+        }
+    }
+
+    /**
+     * Add a listener that informs when the user wants to close the dialog by
+     * clicking outside the dialog, or by pressing escape. Then you can decide
+     * whether to close or to keep opened the dialog. You need to disable the
+     * client-side closing feature by setting to false `closeOnOutsideClick` and
+     * `closeOnEsc` properties.
+     *
+     * @param listener
+     * @return registration for removal of listener
+     */
+    public Registration addDialogCloseActionListener(ComponentEventListener<DialogCloseActionEvent> listener) {
+        return addListener(DialogCloseActionEvent.class, listener);
     }
 
     /**

--- a/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -44,7 +44,6 @@ public class DialogView extends DemoView {
         // source-example-heading: Basic dialog
         Dialog dialog = new Dialog();
         dialog.add(new Label("Close me with the esc-key or an outside click"));
-        dialog.addDialogCloseActionListener(event -> dialog.close());
 
         button.addClickListener(event -> dialog.open());
         // end-source-example

--- a/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -44,6 +44,7 @@ public class DialogView extends DemoView {
         // source-example-heading: Basic dialog
         Dialog dialog = new Dialog();
         dialog.add(new Label("Close me with the esc-key or an outside click"));
+        dialog.addDialogCloseActionListener(event -> dialog.close());
 
         button.addClickListener(event -> dialog.open());
         // end-source-example

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -80,7 +80,6 @@ public class DialogTestPage extends Div {
 
         Dialog dialog = new Dialog();
         dialog.setId("dialog-outside-ui");
-        dialog.addDialogCloseActionListener(e -> dialog.close());
         dialog.add(new Label("Hei! Moika! Moi!"), close);
 
         open.addClickListener(event -> dialog.open());

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -53,6 +53,9 @@ public class DialogTestPage extends Div {
         eventSourceMessage.setId("event-source-message");
 
         Dialog dialog = new Dialog();
+        dialog.setId("dialog");
+        dialog.addDialogCloseActionListener(e -> dialog.close());
+
         message.setText("The open state of the dialog is " + dialog.isOpened());
         dialog.add(
                 new Label("There is a opened change listener for this dialog"));
@@ -77,6 +80,7 @@ public class DialogTestPage extends Div {
 
         Dialog dialog = new Dialog();
         dialog.setId("dialog-outside-ui");
+        dialog.addDialogCloseActionListener(e -> dialog.close());
         dialog.add(new Label("Hei! Moika! Moi!"), close);
 
         open.addClickListener(event -> dialog.open());

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -70,6 +70,12 @@ public class DialogTestPageIT extends AbstractComponentIT {
                 message.getText());
         Assert.assertEquals("Number of event is 1",
                 eventCounterMessage.getText());
+        Assert.assertEquals("The event came from server",
+                eventSourceMessage.getText());
+
+        findElement(By.id("dialog-open")).click();
+        checkDialogIsOpened();
+        executeScript("arguments[0].opened = false", findElement(By.id("dialog")));
         Assert.assertEquals("The event came from client",
                 eventSourceMessage.getText());
     }


### PR DESCRIPTION
Client-side can close the dialog synchronously when the user presses escape or
clicking outside. This makes server side unable to prevent closing if there
are unsave changes etc. With this change, server side can listen to an event
and decide whether to close the dialog.

Fixes #37

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/52)
<!-- Reviewable:end -->
