### PR TITLE
Adding demo for demoing how to handle server-side close validation

### DIFF
--- a/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -35,6 +35,7 @@ public class DialogView extends DemoView {
     public void initView() {
         addBasicDialog();
         addConfirmationDialog();
+        addCloseFromServerSideDialog();
     }
 
     private void addBasicDialog() {
@@ -79,5 +80,28 @@ public class DialogView extends DemoView {
         messageLabel.setId("confirmation-dialog-label");
         button.setId("confirmation-dialog-button");
         addCard("Confirmation dialog", button, messageLabel);
+    }
+
+    private void addCloseFromServerSideDialog() {
+        NativeButton button = new NativeButton(BUTTON_CAPTION);
+
+        // begin-source-example
+        // source-example-heading: Close from server-side
+        Label messageLabel = new Label();
+
+        Dialog dialog = new Dialog(new Label("Close me with the esc-key"));
+        dialog.setCloseOnOutsideClick(false);
+
+        dialog.addDialogCloseActionListener(e -> {
+            messageLabel.setText("Closed from server-side");
+            dialog.close();
+        });
+        // end-source-example
+
+        button.addClickListener(event -> dialog.open());
+
+        messageLabel.setId("server-side-close-dialog-label");
+        button.setId("server-side-close-dialog-button");
+        addCard("Close from server-side", button, messageLabel);
     }
 }

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -57,6 +57,21 @@ public class DialogIT extends ComponentDemoTest {
         Assert.assertEquals("Cancelled...", messageLabel.getText());
     }
 
+    @Test
+    public void validateClosingFromServerSide() {
+        findElement(By.id("server-side-close-dialog-button")).click();
+        verifyDialogOpened();
+
+        executeScript("document.body.click()");
+        verifyDialogOpened();
+
+        new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
+        verifyDialogClosed();
+
+        Assert.assertEquals("Closed from server-side",
+                findElement(By.id("server-side-close-dialog-label")).getText());
+    }
+
     private WebElement getOverlayContent() {
         WebElement overlay = findElement(By.tagName(DIALOG_OVERLAY_TAG));
         return getInShadowRoot(overlay, By.id("content"));
@@ -64,6 +79,10 @@ public class DialogIT extends ComponentDemoTest {
 
     private void verifyDialogClosed() {
         waitForElementNotPresent(By.tagName(DIALOG_OVERLAY_TAG));
+    }
+
+    private void verifyDialogOpened() {
+        waitForElementPresent(By.tagName(DIALOG_OVERLAY_TAG));
     }
 
     @Override


### PR DESCRIPTION
A demo for server-side validation was missing. Adding it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/56)
<!-- Reviewable:end -->
