### PR TITLE
 Update vaadin-dialog to 2.0.0-beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-dialog</artifactId>
-            <version>2.0.0-beta3</version>
+            <version>2.0.0-beta4</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -76,8 +76,7 @@ public class DialogIT extends ComponentDemoTest {
     }
 
     private WebElement getOverlayContent() {
-        WebElement overlay = findElement(By.tagName(DIALOG_OVERLAY_TAG));
-        return getInShadowRoot(overlay, By.id("content"));
+        return findElement(By.tagName(DIALOG_OVERLAY_TAG));
     }
 
     private void verifyDialogClosed() {

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -96,8 +96,8 @@ public class DialogTestPageIT extends AbstractComponentIT {
         waitForElementPresent(By.id("dialog-outside-ui"));
         checkDialogIsOpened();
         WebElement overlay = findElement(By.tagName(DIALOG_OVERLAY_TAG));
-        WebElement close = findInShadowRoot(overlay,
-                By.id("dialog-outside-ui-close")).get(0);
+        WebElement close = overlay
+                .findElement(By.id("dialog-outside-ui-close"));
         close.click();
         checkDialogIsClosed();
         waitForElementNotPresent(By.id("dialog-outside-ui"));

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithTemplateIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogWithTemplateIT.java
@@ -43,8 +43,7 @@ public class DialogWithTemplateIT extends AbstractComponentIT {
         waitForElementPresent(By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
         WebElement overlay = findElement(
                 By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
-        WebElement template = findInShadowRoot(overlay, By.id("template"))
-                .get(0);
+        WebElement template = overlay.findElement(By.id("template"));
 
         WebElement btn = findInShadowRoot(template, By.id("btn")).get(0);
         WebElement container = findInShadowRoot(template, By.id("container"))

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/InitiallyOpenedDialogPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/InitiallyOpenedDialogPageIT.java
@@ -37,7 +37,6 @@ public class InitiallyOpenedDialogPageIT extends AbstractComponentIT {
         waitForElementPresent(By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
         WebElement overlay = findElement(
                 By.tagName(DialogTestPageIT.DIALOG_OVERLAY_TAG));
-        Assert.assertTrue(
-                isPresentInShadowRoot(overlay, By.id("nested-component")));
+        Assert.assertTrue(isElementPresent(By.id("nested-component")));
     }
 }


### PR DESCRIPTION
Fix IT tests, as `flow-component-renderer` is not inside the `vaadin-overlay` shadowroot
anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/58)
<!-- Reviewable:end -->
