### PR TITLE
Adding a test for checking that we can focus internal elements.

### DIFF
--- a/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component.dialog.demo;
 
 import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.demo.DemoView;
@@ -36,6 +37,7 @@ public class DialogView extends DemoView {
         addBasicDialog();
         addConfirmationDialog();
         addCloseFromServerSideDialog();
+        addDialogWithFocusedElement();
     }
 
     private void addBasicDialog() {
@@ -106,5 +108,25 @@ public class DialogView extends DemoView {
         messageLabel.setId("server-side-close-dialog-label");
         button.setId("server-side-close-dialog-button");
         addCard("Close from server-side", button, messageLabel);
+    }
+
+    private void addDialogWithFocusedElement() {
+        NativeButton button = new NativeButton(BUTTON_CAPTION);
+
+        // begin-source-example
+        // source-example-heading: Focus internal Element
+        Dialog dialog = new Dialog();
+        Input input = new Input();
+
+        dialog.add(input);
+
+        button.addClickListener(event -> {
+            dialog.open();
+            input.getElement().callFunction("focus");
+        });
+        // end-source-example
+
+        button.setId("focus-dialog-button");
+        addCard("Focus internal Element", button);
     }
 }

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -75,6 +75,15 @@ public class DialogIT extends ComponentDemoTest {
                 findElement(By.id("server-side-close-dialog-label")).getText());
     }
 
+    @Test
+    public void focusElementOnOpen() {
+        findElement(By.id("focus-dialog-button")).click();
+
+        WebElement element = getOverlayContent().findElement(By.tagName("input"));
+
+        Assert.assertTrue(element.equals(driver.switchTo().activeElement()));
+    }
+
     private WebElement getOverlayContent() {
         return findElement(By.tagName(DIALOG_OVERLAY_TAG));
     }


### PR DESCRIPTION
This is an issue fixed in lates vaadin-overlay release, thus
we do not have to fix anything, just test that it works.

Closes #55

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/59)
<!-- Reviewable:end -->
