### PR TITLE
Add default min width for dialog.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target/
 #selenium
 error-screenshots
 reference-screenshots
+*.iml
+.idea

--- a/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -54,6 +54,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendChild(template);
 
         container = new Element("div");
+        container.getStyle().set("min-width", "500px");
         getElement().appendChild(container);
 
         // Attach <flow-component-renderer>
@@ -85,6 +86,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     @Override
     public void setWidth(String value) {
+        container.getStyle().remove("min-width");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, value);
     }
 

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -38,11 +38,20 @@ public class DialogIT extends ComponentDemoTest {
 
         WebElement container = getOverlayContent()
                 .findElement(By.tagName("div"));
-        Assert.assertEquals("400px", container.getCssValue("width"));
+        Assert.assertEquals("500px", container.getCssValue("width"));
         Assert.assertEquals("150px", container.getCssValue("height"));
 
         new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
         verifyDialogClosed();
+    }
+
+    @Test
+    public void openBasicDialog_minWidthUsed() {
+        findElement(By.id("basic-dialog-button")).click();
+
+        WebElement container = getOverlayContent()
+                .findElement(By.tagName("div"));
+        Assert.assertEquals("500px", container.getCssValue("width"));
     }
 
     @Test

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -38,7 +38,7 @@ public class DialogIT extends ComponentDemoTest {
 
         WebElement container = getOverlayContent()
                 .findElement(By.tagName("div"));
-        Assert.assertEquals("500px", container.getCssValue("width"));
+        Assert.assertEquals("400px", container.getCssValue("width"));
         Assert.assertEquals("150px", container.getCssValue("height"));
 
         new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
@@ -47,7 +47,7 @@ public class DialogIT extends ComponentDemoTest {
 
     @Test
     public void openBasicDialog_minWidthUsed() {
-        findElement(By.id("basic-dialog-button")).click();
+        findElement(By.id("confirmation-dialog-label")).click();
 
         WebElement container = getOverlayContent()
                 .findElement(By.tagName("div"));

--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -47,7 +47,7 @@ public class DialogIT extends ComponentDemoTest {
 
     @Test
     public void openBasicDialog_minWidthUsed() {
-        findElement(By.id("confirmation-dialog-label")).click();
+        findElement(By.id("confirmation-dialog-button")).click();
 
         WebElement container = getOverlayContent()
                 .findElement(By.tagName("div"));


### PR DESCRIPTION
So that any component added to the
dialog is shown a min width is added.
Using setWidth will remove the
min-width value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/70)
<!-- Reviewable:end -->
