### PR TITLE
Correct the IT test

### DIFF
--- a/src/test/java/com/vaadin/flow/component/dialog/tests/CloseListenerReopenDialogIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/CloseListenerReopenDialogIT.java
@@ -84,7 +84,7 @@ public class CloseListenerReopenDialogIT extends AbstractComponentIT {
         closeDialog();
 
         // Dialog should be closed
-        waitUntil(driver -> isElementPresent(
+        waitUntilNot(driver -> isElementPresent(
                 By.tagName("vaadin-dialog-overlay")));
     }
 


### PR DESCRIPTION
After close the dialog, the checking should not wait for the overlay to
present

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/93)
<!-- Reviewable:end -->
