### PR TITLE
1.2 cherry picks

### DIFF
--- a/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -140,6 +140,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         assertButtonNumberInDialog(initialNumber);
         new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
         waitForElementNotPresent(By.id("dialog-add-component-at-index"));
+        waitForElementNotPresent(By.cssSelector(DIALOG_OVERLAY_TAG));
     }
 
     private void assertButtonNumberInDialog(int expectedButtonNumber) {


### PR DESCRIPTION
Cherry-picks:
- Adding a wait for the dialog overlay to disappear to fix two unstable tests(openDialogAddComponentAtFirst, openDialogAddComponentAtIndex) (#106)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/114)
<!-- Reviewable:end -->
