### PR TITLE
Update renderer innerHTML on each attach to work properly with @PreserveOnRefresh

### DIFF
--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -60,10 +60,11 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         container = new Element("div");
         getElement().appendVirtualChild(container);
 
-        // Attach <flow-component-renderer>
-        getElement().getNode()
-                .runWhenAttached(ui -> ui.beforeClientResponse(this,
-                        context -> attachComponentRenderer()));
+        // Attach <flow-component-renderer>. Needs to be updated on each
+        // attach, as element depends on node id which is subject to change if
+        // the dialog is transferred to another UI, e.g. due to
+        // @PreserveOnRefresh
+        getElement().getNode().addAttachListener(this::attachComponentRenderer);
 
         // Workaround for: https://github.com/vaadin/flow/issues/3496
         setOpened(false);


### PR DESCRIPTION
When a route leads to a component annotated with @PreserveOnRefresh, all direct UI children (such as dialogs and notifications) are transferred to the new UI (see https://github.com/vaadin/flow/issues/5608). This requires the dialog to update the renderer on attach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/128)
<!-- Reviewable:end -->
