### PR TITLE
Downgrade major to 2.0 as the latest release was 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>vaadin-dialog-flow-parent</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Vaadin Dialog Flow Parent</name>
 

--- a/vaadin-dialog-flow-demo/pom.xml
+++ b/vaadin-dialog-flow-demo/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-dialog-flow-demo</artifactId>

--- a/vaadin-dialog-flow-integration-tests/pom-bower-mode.xml
+++ b/vaadin-dialog-flow-integration-tests/pom-bower-mode.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.vaadin</groupId>

--- a/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.vaadin</groupId>

--- a/vaadin-dialog-flow-testbench/pom.xml
+++ b/vaadin-dialog-flow-testbench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-dialog-testbench</artifactId>

--- a/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-dialog-flow-parent</artifactId>
-        <version>3.0-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-dialog-flow</artifactId>


### PR DESCRIPTION
Version was upgraded twice first from 1.4 to 2.0 and then 3.0
2.0 shold be the correct version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/129)
<!-- Reviewable:end -->
