### PR TITLE
Use the './' prefix in @JsModule

### DIFF
--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -40,7 +40,7 @@ import com.vaadin.flow.shared.Registration;
  *
  * @author Vaadin Ltd
  */
-@JsModule("flow-component-renderer.js")
+@JsModule("./flow-component-renderer.js")
 @HtmlImport("flow-component-renderer.html")
 public class Dialog extends GeneratedVaadinDialog<Dialog>
         implements HasComponents, HasSize {


### PR DESCRIPTION
This prevents the following warning in projects using vaadin-dialog-flow
>[WARNING] Use the './' prefix for resources in JAR files: 'flow-component-renderer.js', please update your component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-dialog-flow/133)
<!-- Reviewable:end -->
