### PR TITLE
Add DialogResizeEvent and sync width/height

### DIFF
--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -176,6 +176,13 @@ public class DialogTestPage extends Div {
         dialog.setId("dialog-resizable");
         dialog.setResizable(true);
 
+        Div message = new Div();
+        message.setId("dialog-resizable-message");
+
+        dialog.addResizeListener(e -> {
+            message.setText("Rezise listener was called");
+        });
+
         NativeButton closeButton = new NativeButton("close",
                 e -> dialog.close());
         closeButton.setId("dialog-resizable-close-button");
@@ -185,6 +192,6 @@ public class DialogTestPage extends Div {
                 e -> dialog.open());
         openDialog.setId("dialog-resizable-open-button");
 
-        add(openDialog);
+        add(openDialog, message);
     }
 }

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -41,6 +41,7 @@ public class DialogTestPage extends Div {
         createEmptyDialog();
         createDialogAndAddComponentAtIndex();
         createDivInDialog();
+        createResizableDialog();
     }
 
     private void createDialogWithAddOpenedChangeListener() {
@@ -168,5 +169,22 @@ public class DialogTestPage extends Div {
         dialog.setSizeFull();
         div.setSizeFull();
         add(button);
+    }
+
+    private void createResizableDialog() {
+        Dialog dialog = new Dialog();
+        dialog.setId("dialog-resizable");
+        dialog.setResizable(true);
+
+        NativeButton closeButton = new NativeButton("close",
+                e -> dialog.close());
+        closeButton.setId("dialog-resizable-close-button");
+        dialog.add(closeButton);
+
+        NativeButton openDialog = new NativeButton("open resizable dialog",
+                e -> dialog.open());
+        openDialog.setId("dialog-resizable-open-button");
+
+        add(openDialog);
     }
 }

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -175,13 +175,19 @@ public class DialogTestPage extends Div {
         Dialog dialog = new Dialog();
         dialog.setId("dialog-resizable");
         dialog.setResizable(true);
+        dialog.setWidth("200px");
+        dialog.setHeight("200px");
 
         Div message = new Div();
         message.setId("dialog-resizable-message");
 
-        dialog.addResizeListener(e -> {
-            message.setText("Rezise listener was called");
-        });
+        dialog.addResizeListener(e ->
+                message.setText("Rezise listener called with width (" +
+                e.getWidth() + ") and height (" + e.getHeight() + ")"));
+
+        dialog.addOpenedChangeListener(e ->
+                message.setText("Initial size with width (" +
+                dialog.getWidth() + ") and height (" + dialog.getHeight() + ")"));            
 
         NativeButton closeButton = new NativeButton("close",
                 e -> dialog.close());

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -259,12 +259,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         Long overLayWidthBeforeResize = getSizeFromElement(overlay,
                 ElementConstants.STYLE_WIDTH);
 
-        WebElement resizerSE = getInShadowRoot(overlayContent,
-                By.cssSelector(".resizer.se"));
-
-        Actions resizeAction = new Actions(getDriver());
-        resizeAction.dragAndDropBy(resizerSE, 50, 50);
-        resizeAction.perform();
+        resizeDialog(overlayContent);
 
         Long overLayHeightAfterResize = getSizeFromElement(overlay,
                 ElementConstants.STYLE_HEIGHT);
@@ -288,6 +283,27 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Assert.assertEquals(overLayHeightAfterResize, overLayHeightAfterReopen);
         Assert.assertEquals(overLayWidthAfterResize, overLayWidthAfterReopen);
+    }
+
+    @Test
+    public void resizableDialogListenerIsCalled() {
+        findElement(By.id("dialog-resizable-open-button")).click();
+
+        WebElement overlayContent = getOverlayContent();
+
+        resizeDialog(overlayContent);
+
+        WebElement message = findElement(By.id("dialog-resizable-message"));
+        Assert.assertEquals(message.getText(), "Rezise listener was called");
+    }
+
+    private void resizeDialog(WebElement overlayContent) {
+        WebElement resizerSE = getInShadowRoot(overlayContent, 
+                By.cssSelector(".resizer.se"));
+
+        Actions resizeAction = new Actions(getDriver());
+        resizeAction.dragAndDropBy(resizerSE, 50, 50);
+        resizeAction.perform();
     }
 
     private Long getSizeFromElement(WebElement element, String cssProperty) {

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -272,6 +272,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
                 overLayWidthAfterResize);
 
         findElement(By.id("dialog-resizable-close-button")).click();
+        waitForElementNotPresent(By.tagName(DIALOG_OVERLAY_TAG));
         findElement(By.id("dialog-resizable-open-button")).click();
 
         overlay = getInShadowRoot(getOverlayContent(), By.id("overlay"));

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -15,9 +15,8 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
-import com.vaadin.flow.dom.ElementConstants;
-import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
+import java.util.List;
+
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,7 +27,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import java.util.List;
+import com.vaadin.flow.dom.ElementConstants;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -244,6 +245,53 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Assert.assertEquals(overLayHeightValue - paddingValue * 2,
                 divHeightValue);
+    }
+
+    @Test
+    public void resizableDialogShouldPreserveWidthAndHeight() {
+        findElement(By.id("dialog-resizable-open-button")).click();
+
+        WebElement overlayContent = getOverlayContent();
+        WebElement overlay = getInShadowRoot(overlayContent, By.id("overlay"));
+
+        Long overLayHeightBeforeResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_HEIGHT);
+        Long overLayWidthBeforeResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_WIDTH);
+
+        WebElement resizerSE = getInShadowRoot(overlayContent,
+                By.cssSelector(".resizer.se"));
+
+        Actions resizeAction = new Actions(getDriver());
+        resizeAction.dragAndDropBy(resizerSE, 50, 50);
+        resizeAction.perform();
+
+        Long overLayHeightAfterResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_HEIGHT);
+        Long overLayWidthAfterResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_WIDTH);
+
+        Assert.assertNotEquals(overLayHeightBeforeResize,
+                overLayHeightAfterResize);
+        Assert.assertNotEquals(overLayWidthBeforeResize,
+                overLayWidthAfterResize);
+
+        findElement(By.id("dialog-resizable-close-button")).click();
+        findElement(By.id("dialog-resizable-open-button")).click();
+
+        overlay = getInShadowRoot(getOverlayContent(), By.id("overlay"));
+
+        Long overLayHeightAfterReopen = getSizeFromElement(overlay,
+                ElementConstants.STYLE_HEIGHT);
+        Long overLayWidthAfterReopen = getSizeFromElement(overlay,
+                ElementConstants.STYLE_WIDTH);
+
+        Assert.assertEquals(overLayHeightAfterResize, overLayHeightAfterReopen);
+        Assert.assertEquals(overLayWidthAfterResize, overLayWidthAfterReopen);
+    }
+
+    private Long getSizeFromElement(WebElement element, String cssProperty) {
+        return getLongValue(element.getCssValue(cssProperty));
     }
 
     /**

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -288,13 +288,19 @@ public class DialogTestPageIT extends AbstractComponentIT {
     @Test
     public void resizableDialogListenerIsCalled() {
         findElement(By.id("dialog-resizable-open-button")).click();
+        WebElement message = findElement(By.id("dialog-resizable-message"));
+
+        Assert.assertEquals(
+                "Initial size with width (200px) and height (200px)",
+                message.getText());
 
         WebElement overlayContent = getOverlayContent();
 
         resizeDialog(overlayContent);
 
-        WebElement message = findElement(By.id("dialog-resizable-message"));
-        Assert.assertEquals(message.getText(), "Rezise listener was called");
+        Assert.assertEquals(
+                "Rezise listener called with width (250px) and height (250px)",
+                message.getText());
     }
 
     private void resizeDialog(WebElement overlayContent) {

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.UI;
@@ -80,6 +81,11 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                 autoAddedToTheUi = false;
             }
         });
+
+        ComponentUtil.addListener(this, DialogResizeEvent.class, event -> {
+            setWidth(event.getWidth());
+            setHeight(event.getHeight());
+        });
     }
 
     /**
@@ -90,6 +96,30 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     public static class DialogCloseActionEvent extends ComponentEvent<Dialog> {
         public DialogCloseActionEvent(Dialog source, boolean fromClient) {
             super(source, fromClient);
+        }
+    }
+
+    @DomEvent("resize")
+    public static class DialogResizeEvent extends ComponentEvent<Dialog> {
+
+        private final String width;
+        private final String height;
+        public DialogResizeEvent(
+            Dialog source,
+            boolean fromClient,
+            @EventData("event.detail.width") String width,
+            @EventData("event.detail.height") String height) {
+            super(source, fromClient);
+            this.width = width;
+            this.height = height;
+        }
+
+        public String getWidth() {
+            return width;
+        }
+
+        public String getHeight() {
+            return height;
         }
     }
 
@@ -157,6 +187,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
             openedRegistration.remove();
             registration.remove();
         };
+    }
+
+    public Registration addResizeListener(ComponentEventListener<DialogResizeEvent> listener) {
+        return addListener(DialogResizeEvent.class, listener);
     }
 
     /**

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -99,16 +99,18 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         }
     }
 
-    @DomEvent("resize")
-    public static class DialogResizeEvent extends ComponentEvent<Dialog> {
+    /**
+     * `resize` event is sent when the user finishes resizing the overlay.
+     */
+    @DomEvent("resize") public static class DialogResizeEvent
+            extends ComponentEvent<Dialog> {
 
         private final String width;
         private final String height;
-        public DialogResizeEvent(
-            Dialog source,
-            boolean fromClient,
-            @EventData("event.detail.width") String width,
-            @EventData("event.detail.height") String height) {
+
+        public DialogResizeEvent(Dialog source, boolean fromClient,
+                @EventData("event.detail.width") String width,
+                @EventData("event.detail.height") String height) {
             super(source, fromClient);
             this.width = width;
             this.height = height;
@@ -189,7 +191,19 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         };
     }
 
-    public Registration addResizeListener(ComponentEventListener<DialogResizeEvent> listener) {
+    /**
+     * Adds a listener that is called after user finishes resizing the overlay.
+     * It is called only if resizing is enabled (see
+     * {@link Dialog#setResizable(boolean)}).
+     * <p>
+     * Note: By default, the component will sync the width/height values after
+     * every resizing.
+     *
+     * @param listener
+     * @return registration for removal of listener
+     */
+    public Registration addResizeListener(
+            ComponentEventListener<DialogResizeEvent> listener) {
         return addListener(DialogResizeEvent.class, listener);
     }
 

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -117,10 +117,20 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
             this.height = height;
         }
 
+        /**
+         * Gets the width of the overlay after resize is done
+         *
+         * @return the width in pixels of the overlay
+         */
         public String getWidth() {
             return width;
         }
 
+        /**
+         * Gets the height of the overlay after resize is done
+         *
+         * @return the height in pixels of the overlay
+         */
         public String getHeight() {
             return height;
         }

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -82,7 +82,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
             }
         });
 
-        ComponentUtil.addListener(this, DialogResizeEvent.class, event -> {
+        addListener(DialogResizeEvent.class, event -> {
             setWidth(event.getWidth());
             setHeight(event.getHeight());
         });
@@ -102,7 +102,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     /**
      * `resize` event is sent when the user finishes resizing the overlay.
      */
-    @DomEvent("resize") public static class DialogResizeEvent
+    @DomEvent("resize") 
+    public static class DialogResizeEvent
             extends ComponentEvent<Dialog> {
 
         private final String width;


### PR DESCRIPTION
- Add resize event and method to add listener
- Add default listener to sync client width and height values on every resize
- Add test for checking that dimension is preserved after closing and reopening the same dialog after resize

Closes #151 