### PR TITLE
Cherry-pick new API from 2.1 version

### DIFF
--- a/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.demo.DemoView;
@@ -79,7 +80,7 @@ public class DialogView extends DemoView {
         dialog.setCloseOnEsc(false);
         dialog.setCloseOnOutsideClick(false);
 
-        Span message= new Span();
+        Span message = new Span();
 
         Button confirmButton = new Button("Confirm", event -> {
             message.setText("Confirmed!");
@@ -190,19 +191,15 @@ public class DialogView extends DemoView {
         // begin-source-example
         // source-example-heading: Modeless Draggable Resizable Dialog
         Dialog firstDialog = new Dialog();
-        firstDialog.add(
-            new Label("This is the first dialog"),
-            new Button("Close", e -> firstDialog.close())
-        );
+        firstDialog.add(new Label("This is the first dialog"),
+                new Button("Close", e -> firstDialog.close()));
         firstDialog.setModal(false);
         firstDialog.setDraggable(true);
         firstDialog.setResizable(true);
-        
+
         Dialog secondDialog = new Dialog();
-        secondDialog.add(
-            new Label("This is the second dialog"),
-            new Button("Close", e -> secondDialog.close())
-        );
+        secondDialog.add(new Label("This is the second dialog"),
+                new Button("Close", e -> secondDialog.close()));
         secondDialog.setModal(false);
         secondDialog.setDraggable(true);
         secondDialog.setResizable(true);
@@ -211,6 +208,7 @@ public class DialogView extends DemoView {
         openSecondDialog.addClickListener(e -> secondDialog.open());
         // end-source-example
 
-        addCard("Modeless Draggable Resizable Dialog", openDialog, openSecondDialog, firstDialog);
+        addCard("Modeless Draggable Resizable Dialog", openDialog,
+                openSecondDialog, firstDialog);
     }
 }

--- a/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -131,7 +131,7 @@ public class DialogView extends DemoView {
 
         button.addClickListener(event -> {
             dialog.open();
-            input.getElement().callJsFunction("focus");
+            input.focus();
         });
         // end-source-example
 

--- a/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -47,6 +47,7 @@ public class DialogView extends DemoView {
         addCloseFromServerSideDialog();
         addDialogWithFocusedElement();
         addStyledDialogContent();
+        addModelessDraggableResizableDialog();
     }
 
     private void addBasicDialog() {
@@ -179,5 +180,36 @@ public class DialogView extends DemoView {
 
         button.setId("styled-content-dialog-button");
         addCard("Dialog with styled content", button);
+    }
+
+    private void addModelessDraggableResizableDialog() {
+        NativeButton openDialog = new NativeButton(BUTTON_CAPTION);
+        NativeButton openSecondDialog = new NativeButton("Open another dialog");
+
+        // begin-source-example
+        // source-example-heading: Modeless Draggable Resizable Dialog
+        Dialog firstDialog = new Dialog();
+        firstDialog.add(
+            new Label("This is the first dialog"),
+            new Button("Close", e -> firstDialog.close())
+        );
+        firstDialog.setModal(false);
+        firstDialog.setDraggable(true);
+        firstDialog.setResizable(true);
+        
+        Dialog secondDialog = new Dialog();
+        secondDialog.add(
+            new Label("This is the second dialog"),
+            new Button("Close", e -> secondDialog.close())
+        );
+        secondDialog.setModal(false);
+        secondDialog.setDraggable(true);
+        secondDialog.setResizable(true);
+
+        openDialog.addClickListener(e -> firstDialog.open());
+        openSecondDialog.addClickListener(e -> secondDialog.open());
+        // end-source-example
+
+        addCard("Modeless Draggable Resizable Dialog", openDialog, openSecondDialog, firstDialog);
     }
 }

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -43,7 +43,7 @@ public class DialogTestPage extends Div {
         createEmptyDialog();
         createDialogAndAddComponentAtIndex();
         createDivInDialog();
-        createResizableDialog();
+        createResizableDraggableDialog();
         changeDialogDimensions();
     }
 
@@ -174,15 +174,16 @@ public class DialogTestPage extends Div {
         add(button);
     }
 
-    private void createResizableDialog() {
+    private void createResizableDraggableDialog() {
         Dialog dialog = new Dialog();
-        dialog.setId("dialog-resizable");
+        dialog.setId("dialog-resizable-draggable");
         dialog.setResizable(true);
+        dialog.setDraggable(true);
         dialog.setWidth("200px");
         dialog.setHeight("200px");
 
         Div message = new Div();
-        message.setId("dialog-resizable-message");
+        message.setId("dialog-resizable-draggable-message");
 
         dialog.addResizeListener(e ->
                 message.setText("Rezise listener called with width (" +
@@ -194,12 +195,12 @@ public class DialogTestPage extends Div {
 
         NativeButton closeButton = new NativeButton(CLOSE_CAPTION,
                 e -> dialog.close());
-        closeButton.setId("dialog-resizable-close-button");
+        closeButton.setId("dialog-resizable-draggable-close-button");
         dialog.add(closeButton);
 
         NativeButton openDialog = new NativeButton("open resizable dialog",
                 e -> dialog.open());
-        openDialog.setId("dialog-resizable-open-button");
+        openDialog.setId("dialog-resizable-draggable-open-button");
 
         add(openDialog, message);
     }

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -41,6 +41,7 @@ public class DialogTestPage extends Div {
         createEmptyDialog();
         createDialogAndAddComponentAtIndex();
         createDivInDialog();
+        createResizableDialog();
     }
 
     private void createDialogWithAddOpenedChangeListener() {
@@ -168,5 +169,35 @@ public class DialogTestPage extends Div {
         dialog.setSizeFull();
         div.setSizeFull();
         add(button);
+    }
+
+    private void createResizableDialog() {
+        Dialog dialog = new Dialog();
+        dialog.setId("dialog-resizable");
+        dialog.setResizable(true);
+        dialog.setWidth("200px");
+        dialog.setHeight("200px");
+
+        Div message = new Div();
+        message.setId("dialog-resizable-message");
+
+        dialog.addResizeListener(e ->
+                message.setText("Rezise listener called with width (" +
+                e.getWidth() + ") and height (" + e.getHeight() + ")"));
+
+        dialog.addOpenedChangeListener(e ->
+                message.setText("Initial size with width (" +
+                dialog.getWidth() + ") and height (" + dialog.getHeight() + ")"));            
+
+        NativeButton closeButton = new NativeButton("close",
+                e -> dialog.close());
+        closeButton.setId("dialog-resizable-close-button");
+        dialog.add(closeButton);
+
+        NativeButton openDialog = new NativeButton("open resizable dialog",
+                e -> dialog.open());
+        openDialog.setId("dialog-resizable-open-button");
+
+        add(openDialog, message);
     }
 }

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -40,6 +40,7 @@ public class DialogTestPage extends Div {
         createDialogAddingToTheUiAfterOpening();
         createEmptyDialog();
         createDialogAndAddComponentAtIndex();
+        createDivInDialog();
     }
 
     private void createDialogWithAddOpenedChangeListener() {
@@ -154,4 +155,18 @@ public class DialogTestPage extends Div {
         return button;
     }
 
+    private void createDivInDialog() {
+        Div div = new Div();
+        div.setId("div-in-dialog");
+
+        Dialog dialog = new Dialog(div);
+
+        NativeButton button = new NativeButton("open Dialog",
+                event -> dialog.open());
+        button.setId("button-for-dialog-with-div");
+
+        dialog.setSizeFull();
+        div.setSizeFull();
+        add(button);
+    }
 }

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -30,6 +30,8 @@ import com.vaadin.flow.router.Route;
 @Route("dialog-test")
 public class DialogTestPage extends Div {
 
+    private static final String CLOSE_CAPTION = "close";
+    private static final String SIZE_500PX = "500px";
     private static final String BUTTON_CAPTION = "Open dialog";
 
     private int eventCounter;
@@ -42,6 +44,7 @@ public class DialogTestPage extends Div {
         createDialogAndAddComponentAtIndex();
         createDivInDialog();
         createResizableDialog();
+        changeDialogDimensions();
     }
 
     private void createDialogWithAddOpenedChangeListener() {
@@ -189,7 +192,7 @@ public class DialogTestPage extends Div {
                 message.setText("Initial size with width (" +
                 dialog.getWidth() + ") and height (" + dialog.getHeight() + ")"));            
 
-        NativeButton closeButton = new NativeButton("close",
+        NativeButton closeButton = new NativeButton(CLOSE_CAPTION,
                 e -> dialog.close());
         closeButton.setId("dialog-resizable-close-button");
         dialog.add(closeButton);
@@ -199,5 +202,47 @@ public class DialogTestPage extends Div {
         openDialog.setId("dialog-resizable-open-button");
 
         add(openDialog, message);
+    }
+
+    private void changeDialogDimensions() {
+        Dialog selfAttachedDialog = new Dialog();
+        selfAttachedDialog.setId("dimension-dialog-self-attached");
+        selfAttachedDialog.setModal(false);
+        selfAttachedDialog.add(new NativeButton(CLOSE_CAPTION, 
+                e -> selfAttachedDialog.close()));
+
+        NativeButton openSelfAttachedButton = new NativeButton(
+                "open self attached dialog", e -> selfAttachedDialog.open());
+        openSelfAttachedButton.setId("dimension-open-self-attached-button");
+
+        Dialog attachedDialog = new Dialog();
+        attachedDialog.setId("dimension-dialog-attached");
+        attachedDialog.setModal(false);
+        attachedDialog
+                .add(new NativeButton(CLOSE_CAPTION, e -> attachedDialog.close()));
+
+        NativeButton openAttachedButton = new NativeButton(
+                "open attached dialog", e -> attachedDialog.open());
+        openAttachedButton.setId("dimension-open-attached-button");
+
+        NativeButton changeDimensionSelfAttachedButton = new NativeButton(
+                "change size self attached dialog");
+        changeDimensionSelfAttachedButton
+                .setId("dimension-change-size-self-attached");
+        changeDimensionSelfAttachedButton.addClickListener(e -> {
+            selfAttachedDialog.setWidth(SIZE_500PX);
+            selfAttachedDialog.setHeight(SIZE_500PX);
+        });
+
+        NativeButton changeDimensionAttachedButton = new NativeButton(
+                "change size self attached dialog");
+        changeDimensionAttachedButton.setId("dimension-change-size-attached");
+        changeDimensionAttachedButton.addClickListener(e -> {
+            attachedDialog.setWidth(SIZE_500PX);
+            attachedDialog.setHeight(SIZE_500PX);
+        });
+
+        add(attachedDialog, openSelfAttachedButton, openAttachedButton,
+            changeDimensionSelfAttachedButton, changeDimensionAttachedButton);
     }
 }

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
+import com.vaadin.flow.dom.ElementConstants;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -36,13 +37,38 @@ public class DialogIT extends ComponentDemoTest {
     public void openAndCloseBasicDialog_labelRendered() {
         findElement(By.id("basic-dialog-button")).click();
 
-        WebElement container = getOverlayContent()
-                .findElement(By.tagName("div"));
-        Assert.assertEquals("400px", container.getCssValue("width"));
-        Assert.assertEquals("150px", container.getCssValue("height"));
+        WebElement overlay = getInShadowRoot(getOverlayContent(),
+                By.id("overlay"));
 
-        new Actions(getDriver()).sendKeys(Keys.ESCAPE).perform();
-        verifyDialogClosed();
+        WebElement div = getOverlayContent().findElement(By.tagName("div"));
+        WebElement content = overlay.findElement(By.id("content"));
+
+        String overLayWidth = overlay.getCssValue(ElementConstants.STYLE_WIDTH);
+        int overlayWidthValue = Integer
+                .valueOf(overLayWidth.substring(0, overLayWidth.length() - 2));
+
+        String paddingWidth = content.getCssValue("padding");
+        int paddingValue = Integer
+                .valueOf(paddingWidth.substring(0, paddingWidth.length() - 2));
+
+        String divWidth = div.getCssValue(ElementConstants.STYLE_WIDTH);
+        int divWidthValue = Integer
+                .valueOf(divWidth.substring(0, divWidth.length() - 2));
+
+        Assert.assertEquals(overlayWidthValue - paddingValue * 2,
+                divWidthValue);
+
+        String overLayHeight = overlay
+                .getCssValue(ElementConstants.STYLE_HEIGHT);
+        int overLayHeightValue = Integer.valueOf(
+                overLayHeight.substring(0, overLayHeight.length() - 2));
+
+        String divHeight = div.getCssValue(ElementConstants.STYLE_HEIGHT);
+        int divHeightValue = Integer
+                .valueOf(divHeight.substring(0, divHeight.length() - 2));
+
+        Assert.assertEquals(overLayHeightValue - paddingValue * 2,
+                divHeightValue);
     }
 
     @Test

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -249,7 +249,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
     @Test
     public void resizableDialogShouldPreserveWidthAndHeight() {
-        findElement(By.id("dialog-resizable-open-button")).click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
 
         WebElement overlayContent = getOverlayContent();
         WebElement overlay = getInShadowRoot(overlayContent, By.id("overlay"));
@@ -271,9 +271,9 @@ public class DialogTestPageIT extends AbstractComponentIT {
         Assert.assertNotEquals(overLayWidthBeforeResize,
                 overLayWidthAfterResize);
 
-        findElement(By.id("dialog-resizable-close-button")).click();
+        findElement(By.id("dialog-resizable-draggable-close-button")).click();
         waitForElementNotPresent(By.tagName(DIALOG_OVERLAY_TAG));
-        findElement(By.id("dialog-resizable-open-button")).click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
 
         overlay = getInShadowRoot(getOverlayContent(), By.id("overlay"));
 
@@ -288,8 +288,8 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
     @Test
     public void resizableDialogListenerIsCalled() {
-        findElement(By.id("dialog-resizable-open-button")).click();
-        WebElement message = findElement(By.id("dialog-resizable-message"));
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+        WebElement message = findElement(By.id("dialog-resizable-draggable-message"));
 
         Assert.assertEquals(
                 "Initial size with width (200px) and height (200px)",
@@ -368,6 +368,27 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Assert.assertEquals(overlayWidth, "500px");
         Assert.assertEquals(overlayHeight, "500px");
+    }
+
+    @Test
+    public void draggableDialog_shouldAllowDraggingFromDivContainer() {
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+
+        WebElement overlayContent = getOverlayContent();
+        WebElement container = overlayContent.findElement(By.tagName("div"));
+        WebElement overlay = getInShadowRoot(overlayContent, By.id("overlay"));
+
+        // resizing only to force component to set top/left values
+        resizeDialog(overlayContent);
+        String overlayLeft = overlay.getCssValue("left");
+        String overlayTop = overlay.getCssValue("top");
+
+        Actions dragAction = new Actions(getDriver());
+        dragAction.dragAndDropBy(container, 50, 50);
+        dragAction.perform();
+
+        Assert.assertNotEquals(overlayLeft, overlay.getCssValue("left"));
+        Assert.assertNotEquals(overlayTop, overlay.getCssValue("top"));
     }
 
     /**

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -317,6 +317,59 @@ public class DialogTestPageIT extends AbstractComponentIT {
         return getLongValue(element.getCssValue(cssProperty));
     }
 
+    public void notAttachedDialog_opened_changeDimension() {
+        findElement(By.id("dimension-open-self-attached-button")).click();
+        findElement(By.id("dimension-change-size-self-attached")).click();
+
+        WebElement overlay = getInShadowRoot(getOverlayContent(),
+                By.id("overlay"));
+        String overlayWidth = overlay.getCssValue(ElementConstants.STYLE_WIDTH);
+        String overlayHeight = overlay.getCssValue(ElementConstants.STYLE_HEIGHT);
+
+        Assert.assertEquals(overlayWidth, "500px");
+        Assert.assertEquals(overlayHeight, "500px");
+
+        getOverlayContent().findElement(By.tagName("button")).click();
+        findElement(By.id("dimension-open-self-attached-button")).click();
+        waitForElementPresent(By.tagName(DIALOG_OVERLAY_TAG));
+
+        overlay = getInShadowRoot(getOverlayContent(),
+                By.id("overlay"));
+        overlayWidth = overlay.getCssValue(ElementConstants.STYLE_WIDTH);
+        overlayHeight = overlay.getCssValue(ElementConstants.STYLE_HEIGHT);
+
+        Assert.assertEquals(overlayWidth, "500px");
+        Assert.assertEquals(overlayHeight, "500px");
+    }
+
+    @Test
+    public void attachedDialog_beforeOpen_changeDimension() {
+        // Change size of attached dialog
+        findElement(By.id("dimension-change-size-attached")).click();
+        // Open dialog
+        findElement(By.id("dimension-open-attached-button")).click();
+
+        WebElement overlay = getInShadowRoot(getOverlayContent(),
+                By.id("overlay"));
+        String overlayWidth = overlay.getCssValue(ElementConstants.STYLE_WIDTH);
+        String overlayHeight = overlay.getCssValue(ElementConstants.STYLE_HEIGHT);
+
+        Assert.assertEquals(overlayWidth, "500px");
+        Assert.assertEquals(overlayHeight, "500px");
+
+        getOverlayContent().findElement(By.tagName("button")).click();
+        findElement(By.id("dimension-open-attached-button")).click();
+        waitForElementPresent(By.tagName(DIALOG_OVERLAY_TAG));
+
+        overlay = getInShadowRoot(getOverlayContent(),
+                By.id("overlay"));
+        overlayWidth = overlay.getCssValue(ElementConstants.STYLE_WIDTH);
+        overlayHeight = overlay.getCssValue(ElementConstants.STYLE_HEIGHT);
+
+        Assert.assertEquals(overlayWidth, "500px");
+        Assert.assertEquals(overlayHeight, "500px");
+    }
+
     /**
      * Get the number for a css value with px suffix
      *

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -15,11 +15,9 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-
-import java.util.List;
-
+import com.vaadin.flow.dom.ElementConstants;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,8 +28,10 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import com.vaadin.flow.testutil.AbstractComponentIT;
-import com.vaadin.flow.testutil.TestPath;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 @TestPath("dialog-test")
 public class DialogTestPageIT extends AbstractComponentIT {
@@ -205,6 +205,47 @@ public class DialogTestPageIT extends AbstractComponentIT {
                 greaterThan(endpoint));
     }
 
+    @Test
+    public void verifyDialogFullSize() {
+        findElement(By.id("button-for-dialog-with-div")).click();
+        WebElement overlay = getInShadowRoot(getOverlayContent(),
+                By.id("overlay"));
+        Assert.assertTrue(
+                overlay.getAttribute("style").contains("width: 100%;"));
+        Assert.assertTrue(
+                overlay.getAttribute("style").contains("height: 100%;"));
+
+        WebElement div = findElement(By.id("div-in-dialog"));
+        WebElement content = overlay.findElement(By.id("content"));
+
+        String overLayWidth = overlay.getCssValue(ElementConstants.STYLE_WIDTH);
+        int overlayWidthValue = Integer
+                .valueOf(overLayWidth.substring(0, overLayWidth.length() - 2));
+
+        String paddingWidth = content.getCssValue("padding");
+        int paddingValue = Integer
+                .valueOf(paddingWidth.substring(0, paddingWidth.length() - 2));
+
+        String divWidth = div.getCssValue(ElementConstants.STYLE_WIDTH);
+        int divWidthValue = Integer
+                .valueOf(divWidth.substring(0, divWidth.length() - 2));
+
+        Assert.assertEquals(overlayWidthValue - paddingValue * 2,
+                divWidthValue);
+
+        String overLayHeight = overlay
+                .getCssValue(ElementConstants.STYLE_HEIGHT);
+        int overLayHeightValue = Integer.valueOf(
+                overLayHeight.substring(0, overLayHeight.length() - 2));
+
+        String divHeight = div.getCssValue(ElementConstants.STYLE_HEIGHT);
+        int divHeightValue = Integer
+                .valueOf(divHeight.substring(0, divHeight.length() - 2));
+
+        Assert.assertEquals(overLayHeightValue - paddingValue * 2,
+                divHeightValue);
+    }
+
     /**
      * Get the number for a css value with px suffix
      *
@@ -227,5 +268,9 @@ public class DialogTestPageIT extends AbstractComponentIT {
         }
 
         return Long.parseLong(number.toString());
+    }
+
+    private WebElement getOverlayContent() {
+        return findElement(By.tagName(DIALOG_OVERLAY_TAG));
     }
 }

--- a/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow/pom.xml
@@ -31,7 +31,7 @@
             <version>${flow.version}</version>
             <scope>provided</scope>
         </dependency>
- 
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -306,6 +306,82 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         setOpened(false);
     }
 
+    /**
+     * Sets whether component will open modal or modeless dialog.
+     * <p>
+     * Note: When dialog is set to be modeless, then it's up to you to provide
+     * means for it to be closed (eg. a button that calls {@link Dialog#close()}).
+     * The reason being that a modeless dialog allows user to interact with the
+     * interface under it and won't be closed by clicking outside or the ESC key.
+     * 
+     * @param modal 
+     *          {@code false} to enable dialog to open as modeless modal,
+     *          {@code true} otherwise.
+     */
+    public void setModal(boolean modal) {
+        getElement().setProperty("modeless", !modal);
+    }
+
+    /**
+     * Gets whether component is set as modal or modeless dialog.
+     * 
+     * @return  {@code true} if modal dialog (default),
+     *          {@code false} otherwise.
+     */
+    public boolean isModal() {
+        return !getElement().getProperty("modeless", false);
+    }
+
+    /**
+     * Sets whether dialog is enabled to be dragged by the user or not.
+     * <p>
+     * Note: If draggable is enabled and dialog is opened without first
+     * being explicitly attached to a parent, then it won't restore its
+     * last position in the case the user closes and opens it again.
+     * Reason being that a self attached dialog is removed from the DOM
+     * when it's closed and position is not synched.
+     * 
+     * @param draggable 
+     *          {@code true} to enable dragging of the dialog,
+     *          {@code false} otherwise
+     */
+    public void setDraggable(boolean draggable) {
+        getElement().setProperty("draggable", draggable);
+    }
+
+    /**
+     * Gets whether dialog is enabled to be dragged or not.
+     * 
+     * @return 
+     *      {@code true} if dragging is enabled,
+     *      {@code false} otherwise (default).
+     */
+    public boolean isDaggable() {
+        return getElement().getProperty("draggable", false);
+    }
+
+    /**
+     * Sets whether dialog can be resized by user or not.
+     * 
+     * @param resizable 
+     *          {@code true} to enabled resizing of the dialog,
+     *          {@code false} otherwise. 
+     */
+    public void setResizable(boolean resizable) {
+        getElement().setProperty("resizable", resizable);
+    }
+
+    /**
+     * Gets whether dialog is enabled to be resized or not.
+     * 
+     * @return
+     *      {@code true} if resizing is enabled,
+     *      {@code falsoe} otherwiser (default).
+     */
+    public boolean isResizable() {
+        return getElement().getProperty("resizable", false);
+    }
+
     private UI getCurrentUI() {
         UI ui = UI.getCurrent();
         if (ui == null) {

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.dom.Element;
@@ -59,6 +60,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendChild(template);
 
         container = new Element("div");
+        container.getClassList().add("draggable");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
         container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
 
@@ -395,6 +397,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     /**
      * Sets whether dialog is enabled to be dragged by the user or not.
+     * <p>
+     * To allow an element inside the dialog to be dragged by the user
+     * (for instance, a header inside the dialog), a class {@code "draggable"}
+     * can be added to it (see {@link HasStyle#addClassName(String)}).
      * <p>
      * Note: If draggable is enabled and dialog is opened without first
      * being explicitly attached to a parent, then it won't restore its

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -47,6 +47,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     private Element container;
     private boolean autoAddedToTheUi;
     private int onCloseConfigured;
+    private String width;
+    private String height;
 
     /**
      * Creates an empty dialog.
@@ -56,6 +58,9 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendChild(template);
 
         container = new Element("div");
+        container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
+        container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
+
         getElement().appendVirtualChild(container);
 
         // Attach <flow-component-renderer>. Needs to be updated on each
@@ -88,22 +93,22 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     @Override
     public void setWidth(String value) {
-        container.getStyle().set(ElementConstants.STYLE_WIDTH, value);
+        width = value;
     }
 
     @Override
     public void setHeight(String value) {
-        container.getStyle().set(ElementConstants.STYLE_HEIGHT, value);
+        height = value;
     }
 
     @Override
     public String getWidth() {
-        return container.getStyle().get(ElementConstants.STYLE_WIDTH);
+        return width;
     }
 
     @Override
     public String getHeight() {
-        return container.getStyle().get(ElementConstants.STYLE_HEIGHT);
+        return height;
     }
 
     /**
@@ -431,6 +436,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                 "<flow-component-renderer appid=\"%s\" nodeid=\"%s\"></flow-component-renderer>",
                 appId, nodeId);
         template.setProperty("innerHTML", renderer);
-    }
 
+        getElement().executeJs("this.$.overlay.$.overlay.style.height=$0",
+                height);
+        getElement().executeJs("this.$.overlay.$.overlay.style.width=$0",
+                width);
+    }
 }

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.UI;
@@ -78,6 +79,11 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                 autoAddedToTheUi = false;
             }
         });
+
+        addListener(DialogResizeEvent.class, event -> {
+            setWidth(event.getWidth());
+            setHeight(event.getHeight());
+        });
     }
 
     /**
@@ -88,6 +94,43 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     public static class DialogCloseActionEvent extends ComponentEvent<Dialog> {
         public DialogCloseActionEvent(Dialog source, boolean fromClient) {
             super(source, fromClient);
+        }
+    }
+
+    /**
+     * `resize` event is sent when the user finishes resizing the overlay.
+     */
+    @DomEvent("resize") 
+    public static class DialogResizeEvent
+            extends ComponentEvent<Dialog> {
+
+        private final String width;
+        private final String height;
+
+        public DialogResizeEvent(Dialog source, boolean fromClient,
+                @EventData("event.detail.width") String width,
+                @EventData("event.detail.height") String height) {
+            super(source, fromClient);
+            this.width = width;
+            this.height = height;
+        }
+
+        /**
+         * Gets the width of the overlay after resize is done
+         *
+         * @return the width in pixels of the overlay
+         */
+        public String getWidth() {
+            return width;
+        }
+
+        /**
+         * Gets the height of the overlay after resize is done
+         *
+         * @return the height in pixels of the overlay
+         */
+        public String getHeight() {
+            return height;
         }
     }
 
@@ -155,6 +198,22 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
             openedRegistration.remove();
             registration.remove();
         };
+    }
+
+    /**
+     * Adds a listener that is called after user finishes resizing the overlay.
+     * It is called only if resizing is enabled (see
+     * {@link Dialog#setResizable(boolean)}).
+     * <p>
+     * Note: By default, the component will sync the width/height values after
+     * every resizing.
+     *
+     * @param listener
+     * @return registration for removal of listener
+     */
+    public Registration addResizeListener(
+            ComponentEventListener<DialogResizeEvent> listener) {
+        return addListener(DialogResizeEvent.class, listener);
     }
 
     /**

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -423,7 +423,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
      *      {@code true} if dragging is enabled,
      *      {@code false} otherwise (default).
      */
-    public boolean isDaggable() {
+    public boolean isDraggable() {
         return getElement().getProperty("draggable", false);
     }
 

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -81,8 +81,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         });
 
         addListener(DialogResizeEvent.class, event -> {
-            setWidth(event.getWidth());
-            setHeight(event.getHeight());
+            width = event.getWidth();
+            height = event.getHeight();
         });
     }
 
@@ -137,11 +137,13 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     @Override
     public void setWidth(String value) {
         width = value;
+        setDimension(ElementConstants.STYLE_WIDTH, value);
     }
 
     @Override
     public void setHeight(String value) {
         height = value;
+        setDimension(ElementConstants.STYLE_HEIGHT, value);
     }
 
     @Override
@@ -564,6 +566,11 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         return super.addDetachListener(listener);
     }
 
+    private void setDimension(String dimension, String value) {
+        getElement()
+            .executeJs("this.$.overlay.$.overlay.style[$0]=$1", dimension, value);
+    }
+
     private void attachComponentRenderer() {
         String appId = UI.getCurrent().getInternals().getAppId();
         int nodeId = container.getNode().getId();
@@ -572,9 +579,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
                 appId, nodeId);
         template.setProperty("innerHTML", renderer);
 
-        getElement().executeJs("this.$.overlay.$.overlay.style.height=$0",
-                height);
-        getElement().executeJs("this.$.overlay.$.overlay.style.width=$0",
-                width);
+        setDimension(ElementConstants.STYLE_WIDTH, width);
+        setDimension(ElementConstants.STYLE_HEIGHT, height);
+
     }
 }

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -53,7 +53,7 @@ import com.vaadin.flow.shared.Registration;
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
         "WebComponent: Vaadin.DialogElement#null", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-dialog")
-@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.3.0-alpha2")
+@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.3.0-alpha3")
 @JsModule("@vaadin/vaadin-dialog/src/vaadin-dialog.js")
 public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
         extends Component {

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -53,7 +53,7 @@ import com.vaadin.flow.shared.Registration;
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
         "WebComponent: Vaadin.DialogElement#null", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-dialog")
-@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.2.1")
+@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.3.0-alpha2")
 @JsModule("@vaadin/vaadin-dialog/src/vaadin-dialog.js")
 public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
         extends Component {

--- a/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -111,7 +111,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations();
+        assertInvocations(3);
     }
 
     @Test
@@ -120,12 +120,12 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertTrue(flushInvocations().isEmpty());
+        Assert.assertEquals(2, flushInvocations().size());
 
         dialog.addDialogCloseActionListener(event -> {
         });
 
-        assertInvocations();
+        assertInvocations(1);
     }
 
     @Test
@@ -144,7 +144,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertTrue(flushInvocations().isEmpty());
+        Assert.assertEquals(2, flushInvocations().size());
     }
 
     @Test
@@ -159,7 +159,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertTrue(flushInvocations().isEmpty());
+        Assert.assertEquals(2, flushInvocations().size());
     }
 
     @Test
@@ -177,7 +177,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations();
+        assertInvocations(1);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations();
+        assertInvocations(3);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class DialogTest {
 
         registration.remove();
 
-        assertInvocations();
+        assertInvocations(3);
     }
 
     @Test
@@ -234,7 +234,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations();
+        assertInvocations(1);
     }
 
     @Test
@@ -258,7 +258,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations();
+        assertInvocations(1);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -283,9 +283,9 @@ public class DialogTest {
         return ui.getInternals().dumpPendingJavaScriptInvocations();
     }
 
-    private void assertInvocations() {
+    private void assertInvocations(int expectedInvocations) {
         List<PendingJavaScriptInvocation> invocations = flushInvocations();
 
-        Assert.assertEquals(1, invocations.size());
+        Assert.assertEquals(expectedInvocations, invocations.size());
     }
 }

--- a/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -271,6 +271,53 @@ public class DialogTest {
         addDivAtIndex(1);
     }
 
+    @Test
+    public void isDraggable_falseByDefault() {
+        Dialog dialog = new Dialog();
+
+        Assert.assertFalse("draggable is false by default", dialog.getElement().getProperty("draggable", false));
+    }
+
+    @Test
+    public void setDraggable_dialogCanBeDraggable() {
+        Dialog dialog = new Dialog();
+        dialog.setDraggable(true);
+
+        Assert.assertTrue("draggable can be set to true", dialog.getElement().getProperty("draggable", false));
+    }
+
+    @Test
+    public void isResizable_falseByDefault() {
+        Dialog dialog = new Dialog();
+
+        Assert.assertFalse("resizable is false by default", dialog.getElement().getProperty("resizable", false));
+    }
+
+    @Test
+    public void setResizable_dialogCanBeResizable() {
+        Dialog dialog = new Dialog();
+        dialog.setResizable(true);
+
+        Assert.assertTrue("resizable can be set to true", dialog.getElement().getProperty("resizable", false));
+    }
+
+    @Test
+    public void isModal_trueByDefault() {
+        Dialog dialog = new Dialog();
+
+        // Element's api "modeless" acts inverted to Flow's api "modal": modeless is false and modal is true by default 
+        Assert.assertTrue("modal is true by default", !dialog.getElement().getProperty("modeless", false));
+    }
+
+    @Test
+    public void setModal_dialogCanBeModeless() {
+        Dialog dialog = new Dialog();
+        dialog.setModal(false);
+
+        // Element's api "modeless" acts inverted to Flow's api "modal": modeless is false and modal is true by default 
+        Assert.assertFalse("modal can be set to false", !dialog.getElement().getProperty("modeless", false));
+    }
+
     private void addDivAtIndex(int index) {
         Dialog dialog = new Dialog();
 


### PR DESCRIPTION
#### Should only be merged after V15 version is stable and snapshot is changed to next minor/major.

This PR contains the following changes made for Dialog Flow `2.1` (_eventually it can be updated to other changes made to `2.1`_):

- 9e6fba0 Fix setting dimension for opened/attached dialog (#157)
- 0dbe08e Add DialogResizeEvent and sync width/height (#155)
- 4a315cc Add Draggable, Resizable and Modal APIs (#153)
- e7b8782 Fix vaadin dialog full size (#147)
- 982bcf4 Allow dragging dialog from div container (#166)
- e2b11a9 fix: isDaggable -> isDraggable typo (#172)

**NOTE** Preferably it would be better to not **_squash_** but **_rebase merge_** to preserve history.