### PR TITLE
Replace labels with Span's and Text's in demo view

### DIFF
--- a/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
+++ b/vaadin-dialog-flow-demo/src/main/java/com/vaadin/flow/component/dialog/demo/DialogView.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.dialog.demo;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dialog.Dialog;
@@ -56,7 +57,7 @@ public class DialogView extends DemoView {
         // begin-source-example
         // source-example-heading: Sized dialog
         Dialog dialog = new Dialog();
-        dialog.add(new Label("Close me with the esc-key or an outside click"));
+        dialog.add(new Text("Close me with the esc-key or an outside click"));
 
         dialog.setWidth("400px");
         dialog.setHeight("150px");
@@ -104,7 +105,7 @@ public class DialogView extends DemoView {
         // source-example-heading: Close from server-side
         Label messageLabel = new Label();
 
-        Dialog dialog = new Dialog(new Label("Close me with the esc-key"));
+        Dialog dialog = new Dialog(new Text("Close me with the esc-key"));
         dialog.setCloseOnOutsideClick(false);
 
         dialog.addDialogCloseActionListener(e -> {

--- a/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-integration-tests/pom.xml
@@ -54,6 +54,15 @@
             <artifactId>vaadin-combo-box-flow</artifactId>
             <version>3.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-button-flow</artifactId>
+            <version>2.0-SNAPSHOT</version>
+        </dependency>
 
         <!--Test scoped -->
         <dependency>

--- a/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-integration-tests/pom.xml
@@ -64,6 +64,12 @@
             <version>2.0-SNAPSHOT</version>
         </dependency>
 
+        <!-- externals -->
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+
         <!--Test scoped -->
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-integration-tests/pom.xml
@@ -41,11 +41,6 @@
             <artifactId>vaadin-dialog-flow</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-dialog-flow-demo</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <!-- Test util -->
         <dependency>

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogView.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogView.java
@@ -13,10 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.dialog.demo;
-
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
+package com.vaadin.flow.component.dialog.tests;
 
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
@@ -24,25 +21,27 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResource;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
 /**
- * View for {@link Dialog} demo.
+ * Page created for testing purposes. Not suitable for demos.
  *
- * @author Vaadin Ltd
+ * @author Vaadin Ltd.
+ *
  */
-@Route("vaadin-dialog")
-public class DialogView extends DemoView {
+@Route("vaadin-dialog-view")
+public class DialogView extends Div {
 
     private static final String BUTTON_CAPTION = "Open dialog";
 
-    @Override
-    public void initView() {
+    public DialogView() {
         addBasicDialog();
         addConfirmationDialog();
         addCloseFromServerSideDialog();
@@ -54,8 +53,6 @@ public class DialogView extends DemoView {
     private void addBasicDialog() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
 
-        // begin-source-example
-        // source-example-heading: Sized dialog
         Dialog dialog = new Dialog();
         dialog.add(new Text("Close me with the esc-key or an outside click"));
 
@@ -63,69 +60,59 @@ public class DialogView extends DemoView {
         dialog.setHeight("150px");
 
         button.addClickListener(event -> dialog.open());
-        // end-source-example
 
         button.setId("basic-dialog-button");
-        addCard("Sized dialog", button);
+        add(new Text("Sized dialog"), button);
     }
 
     private void addConfirmationDialog() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
 
-        // begin-source-example
-        // source-example-heading: Confirmation dialog
         Dialog dialog = new Dialog();
 
         dialog.setCloseOnEsc(false);
         dialog.setCloseOnOutsideClick(false);
 
-        Span message = new Span();
+        Label messageLabel = new Label();
 
         Button confirmButton = new Button("Confirm", event -> {
-            message.setText("Confirmed!");
+            messageLabel.setText("Confirmed!");
             dialog.close();
         });
         Button cancelButton = new Button("Cancel", event -> {
-            message.setText("Cancelled...");
+            messageLabel.setText("Cancelled...");
             dialog.close();
         });
         dialog.add(confirmButton, cancelButton);
-        // end-source-example
         button.addClickListener(event -> dialog.open());
 
-        message.setId("confirmation-dialog-span");
+        messageLabel.setId("confirmation-dialog-label");
         button.setId("confirmation-dialog-button");
-        addCard("Confirmation dialog", button, message);
+        add(new Text("Confirmation dialog"), button, messageLabel);
     }
 
     private void addCloseFromServerSideDialog() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
 
-        // begin-source-example
-        // source-example-heading: Close from server-side
-        Span message = new Span();
+        Label messageLabel = new Label();
 
         Dialog dialog = new Dialog(new Text("Close me with the esc-key"));
         dialog.setCloseOnOutsideClick(false);
 
         dialog.addDialogCloseActionListener(e -> {
-            message.setText("Closed from server-side");
+            messageLabel.setText("Closed from server-side");
             dialog.close();
         });
-        // end-source-example
-
         button.addClickListener(event -> dialog.open());
 
-        message.setId("server-side-close-dialog-span");
+        messageLabel.setId("server-side-close-dialog-label");
         button.setId("server-side-close-dialog-button");
-        addCard("Close from server-side", button, message);
+        add(new Text("Close from server-side"), button, messageLabel);
     }
 
     private void addDialogWithFocusedElement() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
 
-        // begin-source-example
-        // source-example-heading: Focus internal Element
         Dialog dialog = new Dialog();
         Input input = new Input();
 
@@ -135,17 +122,14 @@ public class DialogView extends DemoView {
             dialog.open();
             input.focus();
         });
-        // end-source-example
 
         button.setId("focus-dialog-button");
-        addCard("Focus internal Element", button);
+        add(new Label("Focus internal Element"), button);
     }
 
     private void addStyledDialogContent() {
         NativeButton button = new NativeButton(BUTTON_CAPTION);
 
-        // begin-source-example
-        // source-example-heading: Dialog with styled content
         Dialog dialog = new Dialog();
         Div content = new Div();
         content.addClassName("my-style");
@@ -153,11 +137,9 @@ public class DialogView extends DemoView {
         content.setText("This component is styled using global styles");
         dialog.add(content);
 
-        // @formatter:off
         String styles = ".my-style { "
                 + "  color: red;"
                 + " }";
-        // @formatter:on
 
         /*
          * The code below register the style file dynamically. Normally you
@@ -177,18 +159,15 @@ public class DialogView extends DemoView {
         dialog.setHeight("150px");
 
         button.addClickListener(event -> dialog.open());
-        // end-source-example
 
         button.setId("styled-content-dialog-button");
-        addCard("Dialog with styled content", button);
+        add(new Text("Dialog with styled content"), button);
     }
 
     private void addModelessDraggableResizableDialog() {
         NativeButton openDialog = new NativeButton(BUTTON_CAPTION);
         NativeButton openSecondDialog = new NativeButton("Open another dialog");
 
-        // begin-source-example
-        // source-example-heading: Modeless Draggable Resizable Dialog
         Dialog firstDialog = new Dialog();
         firstDialog.add(
             new Text("This is the first dialog"),
@@ -209,8 +188,7 @@ public class DialogView extends DemoView {
 
         openDialog.addClickListener(e -> firstDialog.open());
         openSecondDialog.addClickListener(e -> secondDialog.open());
-        // end-source-example
 
-        addCard("Modeless Draggable Resizable Dialog", openDialog, openSecondDialog, firstDialog);
+        add(new Text("Modeless Draggable Resizable Dialog"), openDialog, openSecondDialog, firstDialog);
     }
 }

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogIT.java
@@ -16,22 +16,26 @@
 package com.vaadin.flow.component.dialog.tests;
 
 import com.vaadin.flow.dom.ElementConstants;
+import com.vaadin.flow.testutil.AbstractComponentIT;
+import com.vaadin.flow.testutil.TestPath;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
-import com.vaadin.flow.component.dialog.demo.DialogView;
-import com.vaadin.flow.demo.ComponentDemoTest;
 
-/**
- * Integration tests for the {@link DialogView}.
- */
-public class DialogIT extends ComponentDemoTest {
+@TestPath("vaadin-dialog-view")
+public class DialogIT extends AbstractComponentIT {
 
     private static final String DIALOG_OVERLAY_TAG = "vaadin-dialog-overlay";
+
+    @Before
+    public void init() {
+        open();
+    }
 
     @Test
     public void openAndCloseBasicDialog_labelRendered() {
@@ -137,6 +141,6 @@ public class DialogIT extends ComponentDemoTest {
 
     @Override
     protected String getTestPath() {
-        return ("/vaadin-dialog");
+        return ("/vaadin-dialog-view");
     }
 }


### PR DESCRIPTION
Labels should be used in combination with some component as a caption; thus, replacing incorrect usage of them. Instead, `Text` and `Span` are used

Porting https://github.com/vaadin/vaadin-dialog-flow/pull/160 to 2.1 branch for V14 