### PR TITLE
Allow dragging dialog from div container

### DIFF
--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -43,7 +43,7 @@ public class DialogTestPage extends Div {
         createEmptyDialog();
         createDialogAndAddComponentAtIndex();
         createDivInDialog();
-        createResizableDialog();
+        createResizableDraggableDialog();
         changeDialogDimensions();
     }
 
@@ -174,15 +174,16 @@ public class DialogTestPage extends Div {
         add(button);
     }
 
-    private void createResizableDialog() {
+    private void createResizableDraggableDialog() {
         Dialog dialog = new Dialog();
-        dialog.setId("dialog-resizable");
+        dialog.setId("dialog-resizable-draggable");
         dialog.setResizable(true);
+        dialog.setDraggable(true);
         dialog.setWidth("200px");
         dialog.setHeight("200px");
 
         Div message = new Div();
-        message.setId("dialog-resizable-message");
+        message.setId("dialog-resizable-draggable-message");
 
         dialog.addResizeListener(e ->
                 message.setText("Rezise listener called with width (" +
@@ -194,12 +195,12 @@ public class DialogTestPage extends Div {
 
         NativeButton closeButton = new NativeButton(CLOSE_CAPTION,
                 e -> dialog.close());
-        closeButton.setId("dialog-resizable-close-button");
+        closeButton.setId("dialog-resizable-draggable-close-button");
         dialog.add(closeButton);
 
         NativeButton openDialog = new NativeButton("open resizable dialog",
                 e -> dialog.open());
-        openDialog.setId("dialog-resizable-open-button");
+        openDialog.setId("dialog-resizable-draggable-open-button");
 
         add(openDialog, message);
     }

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -383,9 +383,9 @@ public class DialogTestPageIT extends AbstractComponentIT {
         String overlayLeft = overlay.getCssValue("left");
         String overlayTop = overlay.getCssValue("top");
 
-        Actions resizeAction = new Actions(getDriver());
-        resizeAction.dragAndDropBy(container, 50, 50);
-        resizeAction.perform();
+        Actions dragAction = new Actions(getDriver());
+        dragAction.dragAndDropBy(container, 50, 50);
+        dragAction.perform();
 
         Assert.assertNotEquals(overlayLeft, overlay.getCssValue("left"));
         Assert.assertNotEquals(overlayTop, overlay.getCssValue("top"));

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -249,7 +249,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
     @Test
     public void resizableDialogShouldPreserveWidthAndHeight() {
-        findElement(By.id("dialog-resizable-open-button")).click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
 
         WebElement overlayContent = getOverlayContent();
         WebElement overlay = getInShadowRoot(overlayContent, By.id("overlay"));
@@ -271,9 +271,9 @@ public class DialogTestPageIT extends AbstractComponentIT {
         Assert.assertNotEquals(overLayWidthBeforeResize,
                 overLayWidthAfterResize);
 
-        findElement(By.id("dialog-resizable-close-button")).click();
+        findElement(By.id("dialog-resizable-draggable-close-button")).click();
         waitForElementNotPresent(By.tagName(DIALOG_OVERLAY_TAG));
-        findElement(By.id("dialog-resizable-open-button")).click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
 
         overlay = getInShadowRoot(getOverlayContent(), By.id("overlay"));
 
@@ -288,8 +288,8 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
     @Test
     public void resizableDialogListenerIsCalled() {
-        findElement(By.id("dialog-resizable-open-button")).click();
-        WebElement message = findElement(By.id("dialog-resizable-message"));
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+        WebElement message = findElement(By.id("dialog-resizable-draggable-message"));
 
         Assert.assertEquals(
                 "Initial size with width (200px) and height (200px)",
@@ -368,6 +368,27 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         Assert.assertEquals(overlayWidth, "500px");
         Assert.assertEquals(overlayHeight, "500px");
+    }
+
+    @Test
+    public void draggableDialog_shouldAllowDraggingFromDivContainer() {
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+
+        WebElement overlayContent = getOverlayContent();
+        WebElement container = overlayContent.findElement(By.tagName("div"));
+        WebElement overlay = getInShadowRoot(overlayContent, By.id("overlay"));
+
+        // resizing only to force component to set top/left values
+        resizeDialog(overlayContent);
+        String overlayLeft = overlay.getCssValue("left");
+        String overlayTop = overlay.getCssValue("top");
+
+        Actions resizeAction = new Actions(getDriver());
+        resizeAction.dragAndDropBy(container, 50, 50);
+        resizeAction.perform();
+
+        Assert.assertNotEquals(overlayLeft, overlay.getCssValue("left"));
+        Assert.assertNotEquals(overlayTop, overlay.getCssValue("top"));
     }
 
     /**

--- a/vaadin-dialog-flow/pom.xml
+++ b/vaadin-dialog-flow/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-dialog</artifactId>
-            <version>2.3.0-alpha2</version>
+            <version>2.3.0-alpha3</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -61,6 +62,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendChild(template);
 
         container = new Element("div");
+        container.setAttribute("class", "draggable");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
         container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
 
@@ -397,6 +399,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
     /**
      * Sets whether dialog is enabled to be dragged by the user or not.
+     * <p>
+     * To allow an element inside the dialog to be dragged by the user
+     * (for instance, a header inside the dialog), a class {@code "draggable"}
+     * can be added to it (see {@link HasStyle#addClassName(String)}).
      * <p>
      * Note: If draggable is enabled and dialog is opened without first
      * being explicitly attached to a parent, then it won't restore its

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -62,7 +62,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         getElement().appendChild(template);
 
         container = new Element("div");
-        container.setAttribute("class", "draggable");
+        container.getClassList().add("draggable");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
         container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
 

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -54,7 +54,7 @@ import com.vaadin.flow.shared.Registration;
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
         "WebComponent: Vaadin.DialogElement#null", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-dialog")
-@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.3.0-alpha2")
+@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.3.0-alpha3")
 @JsModule("@vaadin/vaadin-dialog/src/vaadin-dialog.js")
 @HtmlImport("frontend://bower_components/vaadin-dialog/src/vaadin-dialog.html")
 public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>


### PR DESCRIPTION
Dialog Flow has a div container where all child element are appended to. That prevented the dialog from being dragged when it started from that container.

`vaadin-dialog@#2.3.0-alpha3` allows to set a class "`draggable`" to mark an element inside the dialog as a valid dragging target.

Fixes #165