### PR TITLE
fix: prevent content margin collapse

### DIFF
--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.dialog.tests;
 
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
@@ -65,8 +66,10 @@ public class DialogTestPage extends Div {
         dialog.addDialogCloseActionListener(e -> dialog.close());
 
         message.setText("The open state of the dialog is " + dialog.isOpened());
-        dialog.add(
-                new Label("There is a opened change listener for this dialog"));
+        Div content = new Div(new Text("There is an opened change listener for this dialog"));
+        content.getElement().getStyle().set("margin-top", "100px");
+
+        dialog.add(content);
         button.addClickListener(event -> dialog.open());
 
         eventCounter = 0;

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -30,6 +30,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.testutil.AbstractComponentIT;
 import com.vaadin.flow.testutil.TestPath;
+import com.vaadin.testbench.TestBenchElement;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -69,7 +70,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
                 eventSourceMessage.getText());
 
         assertDialogContent(
-                "There is a opened change listener for this dialog");
+                "There is an opened change listener for this dialog");
 
         executeScript("document.body.click()");
         checkDialogIsClosed();
@@ -86,6 +87,16 @@ public class DialogTestPageIT extends AbstractComponentIT {
                 findElement(By.id("dialog")));
         Assert.assertEquals("The event came from client",
                 eventSourceMessage.getText());
+    }
+
+    @Test
+    public void dialogWithContentMargin_wrapperDoesNotCollapse() {
+        findElement(By.id("dialog-open")).click();
+
+        WebElement overlay = findElement(By.id("overlay"));
+        TestBenchElement content = (TestBenchElement) findInShadowRoot(overlay, By.id("content")).get(0);
+
+        Assert.assertEquals(content.getProperty("offsetHeight"), content.getProperty("scrollHeight"));
     }
 
     @Test

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -63,6 +63,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         container.getClassList().add("draggable");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
         container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
+        container.getStyle().set("display", "inline-block");
 
         getElement().appendVirtualChild(container);
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-dialog-flow/issues/185

Currently, the content wrapper is a `block`-element. This PR makes it an `inline-block`-element so it wouldn't collapse margins https://www.sitepoint.com/collapsing-margins/