### PR TITLE
fix: set values for min/max height/width correctly 

### DIFF
--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -205,7 +205,15 @@ public class DialogTestPage extends Div {
                 e -> dialog.open());
         openDialog.setId("dialog-resizable-draggable-open-button");
 
-        add(openDialog, message);
+        NativeButton sizeRestrictions = new NativeButton("set resizing restrictions", e -> {
+            dialog.setMinWidth("175px");
+            dialog.setMaxWidth("225px");
+            dialog.setMinHeight("175px");
+            dialog.setMaxHeight("225px");
+        });
+        sizeRestrictions.setId("dialog-resizing-restrictions-button");
+
+        add(openDialog, message, sizeRestrictions);
     }
 
     private void changeDialogDimensions() {

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -270,7 +270,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         Long overLayWidthBeforeResize = getSizeFromElement(overlay,
                 ElementConstants.STYLE_WIDTH);
 
-        resizeDialog(overlayContent);
+        resizeDialog(overlayContent, 50, 50);
 
         Long overLayHeightAfterResize = getSizeFromElement(overlay,
                 ElementConstants.STYLE_HEIGHT);
@@ -298,6 +298,38 @@ public class DialogTestPageIT extends AbstractComponentIT {
     }
 
     @Test
+    public void verifyResizeLimitsAreRespected() {
+        findElement(By.id("dialog-resizing-restrictions-button")).click();
+        findElement(By.id("dialog-resizable-draggable-open-button")).click();
+
+        Long maxValue = 225l;
+        Long minValue = 175l;
+
+        WebElement overlayContent = getOverlayContent();
+        WebElement overlay = getInShadowRoot(overlayContent, By.id("overlay"));
+
+        resizeDialog(overlayContent, 50, 50);
+
+        Long overLayHeightAfterResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_HEIGHT);
+        Long overLayWidthAfterResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_WIDTH);
+        
+        Assert.assertEquals(overLayHeightAfterResize, maxValue);
+        Assert.assertEquals(overLayWidthAfterResize, maxValue);
+
+        resizeDialog(overlayContent, -75, -75);
+
+        overLayHeightAfterResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_HEIGHT);
+        overLayWidthAfterResize = getSizeFromElement(overlay,
+                ElementConstants.STYLE_WIDTH);
+        
+        Assert.assertEquals(overLayHeightAfterResize, minValue);
+        Assert.assertEquals(overLayWidthAfterResize, minValue);
+    }
+
+    @Test
     public void resizableDialogListenerIsCalled() {
         findElement(By.id("dialog-resizable-draggable-open-button")).click();
         WebElement message = findElement(By.id("dialog-resizable-draggable-message"));
@@ -308,19 +340,19 @@ public class DialogTestPageIT extends AbstractComponentIT {
 
         WebElement overlayContent = getOverlayContent();
 
-        resizeDialog(overlayContent);
+        resizeDialog(overlayContent, 50, 50);
 
         Assert.assertEquals(
                 "Rezise listener called with width (250px) and height (250px)",
                 message.getText());
     }
 
-    private void resizeDialog(WebElement overlayContent) {
+    private void resizeDialog(WebElement overlayContent, int xOffset, int yOffset) {
         WebElement resizerSE = getInShadowRoot(overlayContent, 
                 By.cssSelector(".resizer.se"));
 
         Actions resizeAction = new Actions(getDriver());
-        resizeAction.dragAndDropBy(resizerSE, 50, 50);
+        resizeAction.dragAndDropBy(resizerSE, xOffset, yOffset);
         resizeAction.perform();
     }
 
@@ -390,7 +422,7 @@ public class DialogTestPageIT extends AbstractComponentIT {
         WebElement overlay = getInShadowRoot(overlayContent, By.id("overlay"));
 
         // resizing only to force component to set top/left values
-        resizeDialog(overlayContent);
+        resizeDialog(overlayContent, 50, 50);
         String overlayLeft = overlay.getCssValue("left");
         String overlayTop = overlay.getCssValue("top");
 

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -65,6 +65,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
 
         container = new Element("div");
         container.getClassList().add("draggable");
+        container.getClassList().add("draggable-leaf-only");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
         container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
         container.getStyle().set("display", "inline-block");

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -50,7 +50,11 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     private boolean autoAddedToTheUi;
     private int onCloseConfigured;
     private String width;
+    private String minWidth;
+    private String maxWidth;
     private String height;
+    private String minHeight;
+    private String maxHeight;
 
     /**
      * Creates an empty dialog.
@@ -144,9 +148,33 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     }
 
     @Override
+    public void setMinWidth(String value) {
+        minWidth = value;
+        setDimension(ElementConstants.STYLE_MIN_WIDTH, value);
+    }
+
+    @Override
+    public void setMaxWidth(String value) {
+        maxWidth = value;
+        setDimension(ElementConstants.STYLE_MAX_WIDTH, value);
+    }
+
+    @Override
     public void setHeight(String value) {
         height = value;
         setDimension(ElementConstants.STYLE_HEIGHT, value);
+    }
+
+    @Override
+    public void setMinHeight(String value) {
+        minHeight = value;
+        setDimension(ElementConstants.STYLE_MIN_HEIGHT, value);
+    }
+
+    @Override
+    public void setMaxHeight(String value) {
+        maxHeight = value;
+        setDimension(ElementConstants.STYLE_MAX_HEIGHT, value);
     }
 
     @Override
@@ -155,8 +183,28 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
     }
 
     @Override
+    public String getMinWidth() {
+        return minWidth;
+    }
+
+    @Override
+    public String getMaxWidth() {
+        return maxWidth;
+    }
+
+    @Override
     public String getHeight() {
         return height;
+    }
+
+    @Override
+    public String getMinHeight() {
+        return minHeight;
+    }
+
+    @Override
+    public String getMaxHeight() {
+        return maxHeight;
     }
 
     /**
@@ -587,7 +635,10 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         template.setProperty("innerHTML", renderer);
 
         setDimension(ElementConstants.STYLE_WIDTH, width);
+        setDimension(ElementConstants.STYLE_MIN_WIDTH, minWidth);
+        setDimension(ElementConstants.STYLE_MAX_WIDTH, maxWidth);
         setDimension(ElementConstants.STYLE_HEIGHT, height);
-
+        setDimension(ElementConstants.STYLE_MIN_HEIGHT, minHeight);
+        setDimension(ElementConstants.STYLE_MAX_HEIGHT, maxHeight);
     }
 }

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -53,7 +53,7 @@ import com.vaadin.flow.shared.Registration;
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.1-SNAPSHOT",
         "WebComponent: Vaadin.DialogElement#null", "Flow#1.1-SNAPSHOT" })
 @Tag("vaadin-dialog")
-@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.5.1")
+@NpmPackage(value = "@vaadin/vaadin-dialog", version = "2.5.2")
 @JsModule("@vaadin/vaadin-dialog/src/vaadin-dialog.js")
 public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
         extends Component {

--- a/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
+++ b/vaadin-dialog-flow/src/test/java/com/vaadin/flow/component/dialog/DialogTest.java
@@ -111,7 +111,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations(3);
+        assertInvocations(7);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertEquals(2, flushInvocations().size());
+        Assert.assertEquals(6, flushInvocations().size());
 
         dialog.addDialogCloseActionListener(event -> {
         });
@@ -144,7 +144,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertEquals(2, flushInvocations().size());
+        Assert.assertEquals(6, flushInvocations().size());
     }
 
     @Test
@@ -159,7 +159,7 @@ public class DialogTest {
 
         dialog.open();
 
-        Assert.assertEquals(2, flushInvocations().size());
+        Assert.assertEquals(6, flushInvocations().size());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class DialogTest {
 
         dialog.open();
 
-        assertInvocations(3);
+        assertInvocations(7);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class DialogTest {
 
         registration.remove();
 
-        assertInvocations(3);
+        assertInvocations(7);
     }
 
     @Test


### PR DESCRIPTION
Fix #168

Use the same approach as done in width/height setters.

Blocked by https://github.com/vaadin/vaadin-dialog/pull/192