### PR TITLE
fix: prevent showing scrollbar when content fits

### DIFF
--- a/vaadin-dialog-flow-integration-tests/pom.xml
+++ b/vaadin-dialog-flow-integration-tests/pom.xml
@@ -60,6 +60,12 @@
             <version>5.0-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-ordered-layout-flow</artifactId>
+            <version>4.0-SNAPSHOT</version>
+        </dependency>
+
         <!--Test scoped -->
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
+++ b/vaadin-dialog-flow-integration-tests/src/main/java/com/vaadin/flow/component/dialog/tests/DialogTestPage.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 
 /**
@@ -46,6 +47,7 @@ public class DialogTestPage extends Div {
         createDivInDialog();
         createResizableDraggableDialog();
         changeDialogDimensions();
+        addVerticalLayoutWithNoPadding();
     }
 
     private void createDialogWithAddOpenedChangeListener() {
@@ -256,5 +258,17 @@ public class DialogTestPage extends Div {
 
         add(attachedDialog, openSelfAttachedButton, openAttachedButton,
             changeDimensionSelfAttachedButton, changeDimensionAttachedButton);
+    }
+
+    private void addVerticalLayoutWithNoPadding() {
+        NativeButton button = new NativeButton("Dialog with vertical-layout");
+        button.setId("dialog-with-vertical-layout");
+        Dialog dialog = new Dialog();
+        VerticalLayout layout = new VerticalLayout();
+        layout.setPadding(false);
+        layout.add(new Label("content 1"), new Label("content 2"));
+        dialog.add(layout);
+        button.addClickListener(e -> dialog.open());
+        add(button);
     }
 }

--- a/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
+++ b/vaadin-dialog-flow-integration-tests/src/test/java/com/vaadin/flow/component/dialog/tests/DialogTestPageIT.java
@@ -100,6 +100,15 @@ public class DialogTestPageIT extends AbstractComponentIT {
     }
 
     @Test
+    public void dialogWithVerticalLayout_noScrollbar() {
+        findElement(By.id("dialog-with-vertical-layout")).click();
+
+        WebElement overlay = findElement(By.id("overlay"));
+        TestBenchElement content = (TestBenchElement) findInShadowRoot(overlay, By.id("content")).get(0);
+
+        Assert.assertEquals(content.getProperty("offsetHeight"), content.getProperty("scrollHeight"));
+    }
+    @Test
     public void dialogNotAttachedToThePage_openAndClose_dialogIsAttachedAndRemoved() {
         WebElement open = findElement(By.id("dialog-outside-ui-open"));
 

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -68,7 +68,8 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         container.getClassList().add("draggable-leaf-only");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
         container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
-        container.getStyle().set("display", "inline-block");
+        container.getStyle().set("display", "flex");
+        container.getStyle().set("flex-direction", "column");
 
         getElement().appendVirtualChild(container);
 

--- a/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
+++ b/vaadin-dialog-flow/src/main/java/com/vaadin/flow/component/dialog/Dialog.java
@@ -68,8 +68,6 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         container.getClassList().add("draggable-leaf-only");
         container.getStyle().set(ElementConstants.STYLE_WIDTH, "100%");
         container.getStyle().set(ElementConstants.STYLE_HEIGHT, "100%");
-        container.getStyle().set("display", "flex");
-        container.getStyle().set("flex-direction", "column");
 
         getElement().appendVirtualChild(container);
 
@@ -632,7 +630,7 @@ public class Dialog extends GeneratedVaadinDialog<Dialog>
         String appId = UI.getCurrent().getInternals().getAppId();
         int nodeId = container.getNode().getId();
         String renderer = String.format(
-                "<flow-component-renderer appid=\"%s\" nodeid=\"%s\"></flow-component-renderer>",
+                "<flow-component-renderer appid=\"%s\" nodeid=\"%s\" style=\"display: flex; height: 100%%;\"></flow-component-renderer>",
                 appId, nodeId);
         template.setProperty("innerHTML", renderer);
 


### PR DESCRIPTION
Previously, a fix was introduced to prevent vertical scrollbar from showing when content had margin due some margin collapse, so the fix was to force the container to be `inline-block`. This caused a regression for, eg. a VerticalLayout with no padding, which now makes visible scrollbar.

This change makes the internal container to be a flex box with column direction.

Fixes #225